### PR TITLE
precompiled header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # build directories
 .[Bb]uild/
 [Bb]uild/
+.vs-build/
 
 # object files
 *.o

--- a/code/tests/stf/CMakeLists.txt
+++ b/code/tests/stf/CMakeLists.txt
@@ -21,6 +21,10 @@ target_include_directories(tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/pri
 
 target_link_libraries(tests PRIVATE stf GTest::gtest_main)
 
+# set up cpp files with precompiled headers
+# TODO (stouff) consider adding <stf/types.hpp> to this list
+target_precompile_headers(tests PRIVATE <vector> <gtest/gtest.h>)
+
 include(GoogleTest)
 # finds all the tests associated with the executable
 gtest_discover_tests(tests)


### PR DESCRIPTION
## Summary

Sets up a very basic precompiled header file for the tests to (hopefully) help out with compilation time.