### PR TITLE
Clone googletest in configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "code/deps/googletest"]
-	path = code/deps/googletest
-	url = git@github.com:google/googletest.git

--- a/code/deps/CMakeLists.txt
+++ b/code/deps/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTS)
     include(FetchContent)
     
-    # declare and population googletest dependency
+    # declare and populate googletest dependency
     FetchContent_Declare(
         googletest 
         GIT_REPOSITORY https://github.com/google/googletest.git

--- a/code/deps/CMakeLists.txt
+++ b/code/deps/CMakeLists.txt
@@ -1,3 +1,11 @@
 if (BUILD_TESTS)
-    add_subdirectory(googletest)
+    include(FetchContent)
+    
+    # declare and population googletest dependency
+    FetchContent_Declare(
+        googletest 
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+    )
+    FetchContent_MakeAvailable(googletest)
 endif()


### PR DESCRIPTION
## Summary

Instead of setting up `googletest` as a `git submodule`, we now list `googletest` as a dependency in the `cmake` configuration process via `FetchContent`. This is better because we only build tests when this repo is the top-level cmake project. Now consumers of this library will not have to download/install `googletest`. Additionally, they can be on their own version of `googletest` independent from ours.