### PR TITLE
Frustum intersection performance improvements

### DIFF
--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -207,7 +207,7 @@ namespace stf::cam
          */
         bool const intersects(obb_t const& obb) const
         {
-            for (vec_t const& axis : frustum::possible_axes(obb.basis(), m_planes, m_vertices))
+            for (vec_t const& axis : frustum::all_possible_axes(obb.basis(), m_planes, m_vertices))
             {
                 if (axis.length_squared() > math::constants<T>::zero)
                 {
@@ -308,7 +308,7 @@ namespace stf::cam
             BOTTOM = 5
         };
         
-        static std::array<vec_t, 26> possible_axes(basis_t const& basis, std::array<plane_t, c_num_planes> const& planes, vertices const& verts)
+        static std::array<vec_t, 26> all_possible_axes(basis_t const& basis, std::array<plane_t, c_num_planes> const& planes, vertices const& verts)
         {
             std::array<vec_t, 26> axes =
             {
@@ -356,7 +356,7 @@ namespace stf::cam
             };
             m_aabb = aabb_t::fit(points);
 
-            m_canonical_separation_axes = frustum::possible_axes(math::canonical_basis<T, 3>(), m_planes, m_vertices);
+            m_canonical_separation_axes = frustum::all_possible_axes(math::canonical_basis<T, 3>(), m_planes, m_vertices);
         }
 
         std::array<plane_t, c_num_planes> m_planes;

--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -199,7 +199,8 @@ namespace stf::cam
         {
             if (intersects_fast(aabb))  // if the fast check returns true, do a more thorough check to avoid false positives
             {
-                for (vec_t const& axis : m_canonical_separation_axes)
+                // m_canonical_edge_axes contains only the axes defined the cross product of pairs of edges -- the face normals are covered by intersects_fast
+                for (vec_t const& axis : m_canonical_edge_axes)
                 {
                     if (axis.length_squared() > math::constants<T>::zero)
                     {
@@ -225,7 +226,7 @@ namespace stf::cam
          */
         bool const intersects(obb_t const& obb) const
         {
-            for (vec_t const& axis : frustum::all_possible_axes(obb.basis(), m_planes, m_vertices))
+            for (vec_t const& axis : frustum::all_axes(obb.basis(), m_planes, m_vertices))
             {
                 if (axis.length_squared() > math::constants<T>::zero)
                 {
@@ -325,8 +326,27 @@ namespace stf::cam
             TOP    = 4,
             BOTTOM = 5
         };
+
+    private:
         
-        static std::array<vec_t, 26> all_possible_axes(basis_t const& basis, std::array<plane_t, c_num_planes> const& planes, vertices const& verts)
+        static std::array<vec_t, 18> edge_axes(basis_t const& basis, vertices const& verts)
+        {
+            std::array<vec_t, 18> axes = {};
+            // add axes for cross products between pairs of edges from each polyhedra (the box normals and edge directions are the same)
+            for (size_t d = 0; d < 3; ++d)
+            {
+                size_t offset = d * 6;  // offset by how many axes have been written to the array
+                axes[offset + 0] = math::cross(basis[d], math::normalized(verts.ftr - verts.ftl));
+                axes[offset + 1] = math::cross(basis[d], math::normalized(verts.ftr - verts.fbr));
+                axes[offset + 2] = math::cross(basis[d], math::normalized(verts.ftl - verts.ntl));
+                axes[offset + 3] = math::cross(basis[d], math::normalized(verts.ftr - verts.ntr));
+                axes[offset + 4] = math::cross(basis[d], math::normalized(verts.fbl - verts.nbl));
+                axes[offset + 5] = math::cross(basis[d], math::normalized(verts.fbr - verts.nbr));
+            }
+            return axes;
+        }
+
+        static std::array<vec_t, 26> all_axes(basis_t const& basis, std::array<plane_t, c_num_planes> const& planes, vertices const& verts)
         {
             std::array<vec_t, 26> axes =
             {
@@ -341,16 +361,10 @@ namespace stf::cam
                 planes[side::TOP].normal(),
                 planes[side::BOTTOM].normal(),
             };
-            // add axes for cross products between pairs of edges from each polyhedra (the box normals and edge directions are the same)
-            for (size_t d = 0; d < 3; ++d)
+            size_t i = 8;
+            for (vec_t const& axis : frustum::edge_axes(basis, verts))
             {
-                size_t offset = 8 + d * 6;  // offset by how many axes have been written to the array
-                axes[offset + 0] = math::cross(basis[d], math::normalized(verts.ftr - verts.ftl));
-                axes[offset + 1] = math::cross(basis[d], math::normalized(verts.ftr - verts.fbr));
-                axes[offset + 2] = math::cross(basis[d], math::normalized(verts.ftl - verts.ntl));
-                axes[offset + 3] = math::cross(basis[d], math::normalized(verts.ftr - verts.ntr));
-                axes[offset + 4] = math::cross(basis[d], math::normalized(verts.fbl - verts.nbl));
-                axes[offset + 5] = math::cross(basis[d], math::normalized(verts.fbr - verts.nbr));
+                axes[i++] = axis;
             }
             return axes;
         }
@@ -374,13 +388,15 @@ namespace stf::cam
             };
             m_aabb = aabb_t::fit(points);
 
-            m_canonical_separation_axes = frustum::all_possible_axes(math::canonical_basis<T, 3>(), m_planes, m_vertices);
+            m_canonical_edge_axes = frustum::edge_axes(math::canonical_basis<T, 3>(), m_vertices);
         }
+
+    private:
 
         std::array<plane_t, c_num_planes> m_planes;
         vertices m_vertices;
         aabb_t m_aabb;
-        std::array<vec_t, 26> m_canonical_separation_axes;      // separation axes to test when intersecting with an aabb
+        std::array<vec_t, 18> m_canonical_edge_axes;      // additional separation axes to test when intersecting with an aabb
 
     };
 

--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -105,6 +105,24 @@ namespace stf::cam
         }
 
         /**
+         * @brief Compute whether or not an obb is contained in the frustum
+         * @param [in] obb The query obb
+         * @return Whether or not @p aabb is contained in @p this
+         */
+        bool contains(obb_t const& obb) const
+        {
+            for (size_t i = 0; i < c_num_planes; ++i)
+            {
+                // check if the extremity in the direction of the anti-normal is contained in the halfspace
+                plane_t const& plane = m_planes[i];
+                vec_t extremity = obb.extremity(-plane.normal());
+                bool contained = plane.side(extremity) >= math::constants<T>::zero;
+                if (!contained) { return false; }
+            }
+            return true;    // fallthrough to return true
+        }
+
+        /**
          * @brief Compute whether or not an aabb intersects a frustum
          * @param [in] aabb The query aabb
          * @note This algorithm identifies false positives (returns true for some frustum/aabb that don't actually intersect)

--- a/code/src/stf/include/interface/stf/geom/aabb.hpp
+++ b/code/src/stf/include/interface/stf/geom/aabb.hpp
@@ -111,7 +111,7 @@ namespace stf::geom
             vec_t extremity;
             for (size_t i = 0; i < N; ++i)
             {
-                extremity[i] = (direction[i] > 0) ? max[i] : min[i];
+                extremity[i] = (direction[i] > math::constants<T>::zero) ? max[i] : min[i];
             }
             return extremity;
         }

--- a/code/src/stf/include/interface/stf/geom/aabb.hpp
+++ b/code/src/stf/include/interface/stf/geom/aabb.hpp
@@ -196,14 +196,9 @@ namespace stf::geom
          */
         math::interval<T> projection(vec_t const& axis) const
         {
-            math::interval<T> interval(math::constants<T>::pos_inf, math::constants<T>::neg_inf);
-            for (size_t v = 0; v < aabb::vertex_count(); ++v)
-            {
-                T const l = math::dot(vertex(v), axis);
-                interval.a = std::min(interval.a, l);
-                interval.b = std::max(interval.b, l);
-            }
-            return interval;
+            T const a = math::dot(extremity(-axis), axis);
+            T const b = math::dot(extremity( axis), axis);
+            return math::interval<T>(a, b);
         }
 
         /**

--- a/code/src/stf/include/interface/stf/geom/obb.hpp
+++ b/code/src/stf/include/interface/stf/geom/obb.hpp
@@ -157,7 +157,7 @@ namespace stf::geom
         math::interval<T> projection(vec_t const& axis) const
         {
             T const a = math::dot(extremity(-axis), axis);
-            T const b = math::dot( extremity(axis), axis);
+            T const b = math::dot(extremity( axis), axis);
             return math::interval<T>(a, b);
         }
 

--- a/code/src/stf/include/interface/stf/geom/obb.hpp
+++ b/code/src/stf/include/interface/stf/geom/obb.hpp
@@ -100,6 +100,22 @@ namespace stf::geom
         }
 
         /**
+         * @brief Compute an extremity of an @ref obb in a given direction
+         * @param [in] direction
+         * @return A vertex of @p this that is maximally extreme in @p direction
+         */
+        vec_t extremity(vec_t const& direction) const
+        {
+            vec_t extremity = m_center;
+            for (size_t i = 0; i < N; ++i)
+            {
+                T sign = (math::dot(direction, m_basis[i]) > math::constants<T>::zero) ? math::constants<T>::one : -math::constants<T>::one;
+                extremity += sign * m_half_extents[i] * m_basis[i];
+            }
+            return extremity;
+        }
+
+        /**
          * @brief Compute whether a point is contained in an @ref obb
          * @param [in] point
          * @return Whether or not @p point is contained in @p this
@@ -140,14 +156,9 @@ namespace stf::geom
          */
         math::interval<T> projection(vec_t const& axis) const
         {
-            math::interval<T> interval(math::constants<T>::pos_inf, math::constants<T>::neg_inf);
-            for (size_t v = 0; v < obb::vertex_count(); ++v)
-            {
-                T const l = math::dot(vertex(v), axis);
-                interval.a = std::min(interval.a, l);
-                interval.b = std::max(interval.b, l);
-            }
-            return interval;
+            T const a = math::dot(extremity(-axis), axis);
+            T const b = math::dot( extremity(axis), axis);
+            return math::interval<T>(a, b);
         }
 
         /**

--- a/code/tests/stf/cpp/stf/geom/obb2_tests.cpp
+++ b/code/tests/stf/cpp/stf/geom/obb2_tests.cpp
@@ -23,6 +23,47 @@ namespace stf::geom
         }
     }
 
+    TEST(obb2, extremity)
+    {
+        // simple tests
+        std::vector<scaffolding::obb::extremity<float, 2>> tests =
+        {
+            { stff::obb2(stff::aabb2(stff::vec2(0), stff::vec2(1))), stff::vec2(1, 1), stff::vec2(1, 1) },
+            { stff::obb2(stff::aabb2(stff::vec2(0), stff::vec2(1))), stff::vec2(1, -1), stff::vec2(1, 0) },
+            { stff::obb2(stff::aabb2(stff::vec2(0), stff::vec2(1))), stff::vec2(-1, 1), stff::vec2(0, 1) },
+            { stff::obb2(stff::aabb2(stff::vec2(0), stff::vec2(1))), stff::vec2(-1, -1), stff::vec2(0, 0) },
+        };
+
+        // add more complex tests
+        {
+            {
+                stff::vec2 center(0.f);
+                stff::mtx2 rotation = stf::math::rotate(stff::constants::quarter_pi);
+                tests.push_back({ stff::obb2(center, rotation, stff::vec2(1)), stff::vec2(1, 0), stff::vec2(stff::constants::sqrt_two, 0) });
+            }
+            {
+                stff::vec2 center(0.f);
+                stff::mtx2 rotation = stf::math::rotate(stff::constants::quarter_pi);
+                tests.push_back({ stff::obb2(center, rotation, stff::vec2(1)), stff::vec2(0, 1), stff::vec2(0, stff::constants::sqrt_two) });
+            }
+            {
+                stff::vec2 center(0.f);
+                stff::mtx2 rotation = stf::math::rotate(stff::constants::quarter_pi);
+                tests.push_back({ stff::obb2(center, rotation, stff::vec2(1)), stff::vec2(-1, 0), stff::vec2(-stff::constants::sqrt_two, 0) });
+            }
+            {
+                stff::vec2 center(0.f);
+                stff::mtx2 rotation = stf::math::rotate(stff::constants::quarter_pi);
+                tests.push_back({ stff::obb2(center, rotation, stff::vec2(1)), stff::vec2(0, -1), stff::vec2(0, -stff::constants::sqrt_two) });
+            }
+        }
+
+        for (scaffolding::obb::extremity<float, 2> const& test : tests)
+        {
+            scaffolding::obb::verify(test);
+        }
+    }
+
     TEST(obb2, intersect)
     {
         // simple tests

--- a/code/tests/stf/include/private/stf/cam/scaffolding/frustum.hpp
+++ b/code/tests/stf/include/private/stf/cam/scaffolding/frustum.hpp
@@ -21,7 +21,8 @@ namespace stf::cam::scaffolding::frustum
     template<typename T>
     void verify(contains<T> const& test)
     {
-        ASSERT_EQ(test.contains, test.frustum.contains(test.box)) << "Failed to compute frustum::contains";
+        ASSERT_EQ(test.contains, test.frustum.contains(test.box)) << "Failed to compute frustum::contains(aabb)";
+        ASSERT_EQ(test.contains, test.frustum.contains(geom::obb3<T>(test.box))) << "Failed to compute frustum::contains(obb)";
     }
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/obb.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/obb.hpp
@@ -27,6 +27,20 @@ namespace stf::geom::scaffolding::obb
     }
 
     template<typename T, size_t N>
+    struct extremity
+    {
+        geom::obb<T, N> const obb;
+        math::vec<T, N> const axis;
+        math::vec<T, N> const extreme;
+    };
+
+    template<typename T, size_t N>
+    void verify(extremity<T, N> const& test)
+    {
+        ASSERT_EQ(test.extreme, test.obb.extremity(test.axis)) << "failed to compute extremity";
+    }
+
+    template<typename T, size_t N>
     struct contains
     {
         geom::obb<T, N> const obb;


### PR DESCRIPTION
## Summary

This PR improves the projection computation for `aabb` and `obb` objects and avoids testing duplicate axes for `frustum`/`aabb3` intersection