### PR TITLE
Tweak dot product operator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,9 @@ jobs:
         ## Execute test coverage
         run: |
           ./tests
-          llvm-profdata-14 merge default.profraw -o tests.profdata
-          llvm-cov-14 show tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-lines.txt
-          llvm-cov-14 report tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-files.txt
+          llvm-profdata-17 merge default.profraw -o tests.profdata
+          llvm-cov-17 show tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-lines.txt
+          llvm-cov-17 report tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-files.txt
 
       - name: Upload coverage to github
         if: ${{ matrix.build_type == 'Coverage' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,9 @@ jobs:
         ## Execute test coverage
         run: |
           ./tests
-          llvm-profdata-17 merge default.profraw -o tests.profdata
-          llvm-cov-17 show tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-lines.txt
-          llvm-cov-17 report tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-files.txt
+          llvm-profdata-18 merge default.profraw -o tests.profdata
+          llvm-cov-18 show tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-lines.txt
+          llvm-cov-18 report tests -instr-profile=tests.profdata -show-instantiation-summary ${{ steps.strings.outputs.src-dir }} > coverage-files.txt
 
       - name: Upload coverage to github
         if: ${{ matrix.build_type == 'Coverage' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      # - name: Setup ssh session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup ssh session
+        uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      - name: Setup ssh session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup ssh session
+      #   uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/code/src/stf/include/interface/stf/geom/hyperplane.hpp
+++ b/code/src/stf/include/interface/stf/geom/hyperplane.hpp
@@ -47,7 +47,7 @@ namespace stf::geom
          * @param [in] p 
          * @return The signed distance from @p this to @p p
          */
-        T signed_dist(vec_t const& p) const { return m_normal * (p - m_point); }
+        T signed_dist(vec_t const& p) const { return math::dot(m_normal, p - m_point); }
 
         /**
          * @brief Compute the distance from a hyperplane to a point

--- a/code/src/stf/include/interface/stf/geom/ray.hpp
+++ b/code/src/stf/include/interface/stf/geom/ray.hpp
@@ -63,7 +63,7 @@ namespace stf::geom
         T const dist_squared(vec_t const& query) const
         {
             vec_t unit_dir = direction.normalized();
-            T scalar = (query - point) * unit_dir;
+            T scalar = math::dot(query - point, unit_dir);
             T t = std::max(scalar, math::constants<T>::zero);
             vec_t proj = point + t * unit_dir;
             return (query - proj).length_squared();

--- a/code/src/stf/include/interface/stf/geom/segment.hpp
+++ b/code/src/stf/include/interface/stf/geom/segment.hpp
@@ -115,7 +115,7 @@ namespace stf::geom
         T const dist_squared(vec_t const& point) const
         {
             vec_t diff = delta();
-            T scalar = ((point - a) * diff) / (diff * diff);
+            T scalar = math::dot(point - a, diff) / math::dot(diff, diff);
             T t = std::clamp(scalar, math::constants<T>::zero, math::constants<T>::one);
             vec_t proj = a + t * diff;
             return (point - proj).length_squared();

--- a/code/src/stf/include/interface/stf/math/raw.hpp
+++ b/code/src/stf/include/interface/stf/math/raw.hpp
@@ -78,6 +78,22 @@ namespace stf::math::raw
     }
 
     /**
+     * @brief Compute the hadamard product of two vectors (stored as arrays) in place
+     * @tparam T Number type (eg float)
+     * @tparam N Dimension
+     * @param [in,out] lhs
+     * @param [in] rhs
+     */
+    template<typename T, size_t N>
+    inline void hadamard_equals(T lhs[N], T const rhs[N])
+    {
+        for (size_t i = 0; i < N; ++i)
+        {
+            lhs[i] *= rhs[i];
+        }
+    }
+
+    /**
      * @brief Write the prefix of one array into another
      * @tparam T Number type (eg float)
      * @tparam N Dimension

--- a/code/src/stf/include/interface/stf/math/spherical.hpp
+++ b/code/src/stf/include/interface/stf/math/spherical.hpp
@@ -76,7 +76,7 @@ namespace stf::math
     template<typename T>
     inline T counterclockwise_angle(vec2<T> const& u, vec2<T> const& v)
     {
-        return canonical_angle(std::atan2(cross(u, v), u * v));
+        return canonical_angle(std::atan2(cross(u, v), dot(u, v)));
     }
 
     /**

--- a/code/src/stf/include/interface/stf/math/vector.hpp
+++ b/code/src/stf/include/interface/stf/math/vector.hpp
@@ -118,17 +118,24 @@ namespace stf::math
         inline vec& operator*=(T const scalar) { raw::scale<T, N>(values, scalar); return *this; }
 
         /**
-         * @brief Compute a dot product
+         * @brief Compute a hadamard product in place 
          * @param [in] rhs 
+         * @return A reference to @p this
+         */
+        inline vec& operator*=(vec const& rhs) { raw::hadamard_equals<T, N>(values, rhs.values); return *this; }
+
+        /**
+         * @brief Compute a dot product
+         * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const operator*(vec const& rhs) const { return raw::dot<T, N>(values, rhs.values); }
+        inline T const dot(vec const& rhs) const { return raw::dot<T, N>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
          * @return The length squared of @p this
          */
-        inline T length_squared() const { return *this * *this;  }
+        inline T length_squared() const { return dot(*this); }
 
         /**
          * @brief Compute the length of a vector
@@ -153,7 +160,7 @@ namespace stf::math
          * @param [in] rhs The direction of the projection
          * @return The component of @p this in the direction of @p rhs
          */
-        inline vec projected_on(vec const& rhs) const { T scalar = (*this * rhs) / (rhs * rhs); return scalar * rhs; }
+        inline vec projected_on(vec const& rhs) const { T scalar = dot(rhs) / rhs.dot(rhs); return scalar * rhs; }
 
         /**
          * @brief Compute the component of a vector orthogonal to another vector
@@ -266,17 +273,24 @@ namespace stf::math
         inline vec& operator*=(T const scalar) { raw::scale<T, 2>(values, scalar); return *this; }
 
         /**
+         * @brief Compute a hadamard product in place
+         * @param [in] rhs
+         * @return A reference to @p this
+         */
+        inline vec& operator*=(vec const& rhs) { raw::hadamard_equals<T, 2>(values, rhs.values); return *this; }
+
+        /**
          * @brief Compute a dot product
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const operator*(vec const& rhs) const { return raw::dot<T, 2>(values, rhs.values); }
+        inline T const dot(vec const& rhs) const { return raw::dot<T, 2>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
          * @return The length squared of @p this
          */
-        inline T length_squared() const { return *this * *this; }
+        inline T length_squared() const { return dot(*this); }
 
         /**
          * @brief Compute the length of a vector
@@ -301,7 +315,7 @@ namespace stf::math
          * @param [in] rhs The direction of the projection
          * @return The component of @p this in the direction of @p rhs
          */
-        inline vec projected_on(vec const& rhs) const { T scalar = (*this * rhs) / (rhs * rhs); return scalar * rhs; }
+        inline vec projected_on(vec const& rhs) const { T scalar = dot(rhs) / rhs.dot(rhs); return scalar * rhs; }
 
         /**
          * @brief Compute the component of a vector orthogonal to another vector
@@ -421,17 +435,24 @@ namespace stf::math
         inline vec& operator*=(T const scalar) { raw::scale<T, 3>(values, scalar); return *this; }
 
         /**
+         * @brief Compute a hadamard product in place
+         * @param [in] rhs
+         * @return A reference to @p this
+         */
+        inline vec& operator*=(vec const& rhs) { raw::hadamard_equals<T, 3>(values, rhs.values); return *this; }
+
+        /**
          * @brief Compute a dot product
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const operator*(vec const& rhs) const { return raw::dot<T, 3>(values, rhs.values); }
+        inline T const dot(vec const& rhs) const { return raw::dot<T, 3>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
          * @return The length squared of @p this
          */
-        inline T length_squared() const { return *this * *this; }
+        inline T length_squared() const { return dot(*this); }
 
         /**
          * @brief Compute the length of a vector
@@ -456,7 +477,7 @@ namespace stf::math
          * @param [in] rhs The direction of the projection
          * @return The component of @p this in the direction of @p rhs
          */
-        inline vec projected_on(vec const& rhs) const { T scalar = (*this * rhs) / (rhs * rhs); return scalar * rhs; }
+        inline vec projected_on(vec const& rhs) const { T scalar = dot(rhs) / rhs.dot(rhs); return scalar * rhs; }
         
         /**
          * @brief Compute the component of a vector orthogonal to another vector
@@ -585,17 +606,24 @@ namespace stf::math
         inline vec& operator*=(T const scalar) { raw::scale<T, 4>(values, scalar); return *this; }
 
         /**
+         * @brief Compute a hadamard product in place
+         * @param [in] rhs
+         * @return A reference to @p this
+         */
+        inline vec& operator*=(vec const& rhs) { raw::hadamard_equals<T, 4>(values, rhs.values); return *this; }
+
+        /**
          * @brief Compute a dot product
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const operator*(vec const& rhs) const { return raw::dot<T, 4>(values, rhs.values); }
+        inline T const dot(vec const& rhs) const { return raw::dot<T, 4>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
          * @return The length squared of @p this
          */
-        inline T length_squared() const { return *this * *this; }
+        inline T length_squared() const { return dot(*this); }
 
         /**
          * @brief Compute the length of a vector
@@ -620,7 +648,7 @@ namespace stf::math
          * @param [in] rhs The direction of the projection
          * @return The component of @p this in the direction of @p rhs
          */
-        inline vec projected_on(vec const& rhs) const { T scalar = (*this * rhs) / (rhs * rhs); return scalar * rhs; }
+        inline vec projected_on(vec const& rhs) const { T scalar = dot(rhs) / rhs.dot(rhs); return scalar * rhs; }
 
         /**
          * @brief Compute the component of a vector orthogonal to another vector
@@ -861,7 +889,7 @@ namespace stf::math
     template<typename T, size_t N>
     inline T const dot(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
-        return lhs * rhs;
+        return raw::dot<T, N>(lhs.values, rhs.values);
     }
 
     /** 
@@ -936,13 +964,29 @@ namespace stf::math
     template<typename T, size_t N>
     inline vec<T, N> const hadamard(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
-        vec<T, N> result;
-        for (size_t i = 0; i < N; ++i)
-        {
-            result[i] = lhs[i] * rhs[i];
-        }
-        return result;
+        return vec<T, N>(lhs) *= (rhs);
+
+        //vec<T, N> result;
+        //for (size_t i = 0; i < N; ++i)
+        //{
+        //    result[i] = lhs[i] * rhs[i];
+        //}
+        //return result;
     }
+
+    /**
+     * @brief Compute the hadamard product of @p lhs and @p rhs
+     *
+     * The hadamard product is element-wise multiplication of vectors.
+     *
+     * @tparam T Number type (eg float)
+     * @tparam N Dimension
+     * @param [in] lhs
+     * @param [in] rhs
+     * @return The hadamard product of @p lhs and @p rhs
+     */
+    template<typename T, size_t N>
+    inline vec<T, N> const operator*(vec<T, N> const& lhs, vec<T, N> const& rhs) { return hadamard(lhs, rhs); }
 
     /**
      * @brief Compute the prefix of a vector

--- a/code/tests/stf/include/private/stf/math/scaffolding/vector.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/vector.hpp
@@ -160,8 +160,10 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     void verify(dot<T, N> const& test)
     {
-        ASSERT_EQ(test.expected, test.lhs * test.rhs) << "Failed lhs * rhs";
-        ASSERT_EQ(test.expected, test.rhs * test.lhs) << "Failed rhs * lhs";
+        ASSERT_EQ(test.expected, math::dot(test.lhs, test.rhs)) << "Failed dot(lhs, rhs)";
+        ASSERT_EQ(test.expected, math::dot(test.rhs, test.lhs)) << "Failed dot(rhs, lhs)";
+        ASSERT_EQ(test.expected, test.lhs.dot(test.rhs)) << "Failed lhs.dot(rhs)";
+        ASSERT_EQ(test.expected, test.rhs.dot(test.lhs)) << "Failed rhs.dot(lhs)";
     }
 
     template<typename T, size_t N>


### PR DESCRIPTION
## Summary

This PR refactors `operator*(vec, vec)` to be the hadamard product and adds some explicit `dot` product functions