### PR TITLE
Const correctness

### DIFF
--- a/code/src/stf/include/interface/stf/alg/intersect.hpp
+++ b/code/src/stf/include/interface/stf/alg/intersect.hpp
@@ -51,7 +51,7 @@ namespace stf::alg
      * @return Whether or not @p lhs intersects @p rhs
      */
     template<typename T>
-    inline bool const intersect(geom::obb2<T> const& lhs, geom::obb2<T> const& rhs)
+    inline bool intersect(geom::obb2<T> const& lhs, geom::obb2<T> const& rhs)
     {
         return geom::intersect(lhs, rhs);
     }
@@ -64,7 +64,7 @@ namespace stf::alg
      * @return Whether or not @p lhs intersects @p rhs
      */
     template<typename T>
-    inline bool const intersect(geom::obb3<T> const& lhs, geom::obb3<T> const& rhs)
+    inline bool intersect(geom::obb3<T> const& lhs, geom::obb3<T> const& rhs)
     {
         return geom::intersect(lhs, rhs);
     }

--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -195,7 +195,7 @@ namespace stf::cam
          * @param [in] aabb The query aabb
          * @return Whether or not @p aabb intersect @p this
          */
-        bool const intersects(aabb_t const& aabb) const
+        bool intersects(aabb_t const& aabb) const
         {
             if (intersects_fast(aabb))  // if the fast check returns true, do a more thorough check to avoid false positives
             {
@@ -224,7 +224,7 @@ namespace stf::cam
          * @param [in] obb The query obb
          * @return Whether or not @p obb intersect @p this
          */
-        bool const intersects(obb_t const& obb) const
+        bool intersects(obb_t const& obb) const
         {
             for (vec_t const& axis : frustum::all_axes(obb.basis(), m_planes, m_vertices))
             {
@@ -246,7 +246,7 @@ namespace stf::cam
          * @return The interval of projection onto the axis
          * @note @p axis is assumed to be a unit vector
          */
-        interval_t const projection(vec_t const& axis) const
+        interval_t projection(vec_t const& axis) const
         {
             interval_t interval(math::constants<T>::pos_inf, math::constants<T>::neg_inf);
             std::array<vec_t, 8> points =

--- a/code/src/stf/include/interface/stf/cam/scamera.hpp
+++ b/code/src/stf/include/interface/stf/cam/scamera.hpp
@@ -206,7 +206,7 @@ namespace stf::cam
      * @return Whether or not @p lhs and @p rhs are closer than @p eps
      */
     template<typename T>
-    inline bool const equ(scamera<T> const& lhs, scamera<T> const& rhs, T eps)
+    inline bool equ(scamera<T> const& lhs, scamera<T> const& rhs, T eps)
     {
         return equ(lhs.eye, rhs.eye, eps)
                 && math::equ(lhs.theta, rhs.theta, eps)
@@ -227,7 +227,7 @@ namespace stf::cam
      * @return Whether or not @p lhs and @p rhs are further apart than @p eps
      */
     template<typename T>
-    inline bool const neq(scamera<T> const& lhs, scamera<T> const& rhs, T eps)
+    inline bool neq(scamera<T> const& lhs, scamera<T> const& rhs, T eps)
     {
         return !equ(lhs, rhs, eps);
     }
@@ -241,7 +241,7 @@ namespace stf::cam
      * @return Whether or not @p lhs and @p rhs are approximately equal
      */
     template<typename T>
-    inline bool const operator==(scamera<T> const& lhs, scamera<T> const& rhs)
+    inline bool operator==(scamera<T> const& lhs, scamera<T> const& rhs)
     {
         return equ(lhs, rhs, math::constants<T>::tol);
     }
@@ -255,7 +255,7 @@ namespace stf::cam
      * @return Whether or not @p lhs and @p rhs are approximately not equal
      */
     template<typename T>
-    inline bool const operator!=(scamera<T> const& lhs, scamera<T> const& rhs)
+    inline bool operator!=(scamera<T> const& lhs, scamera<T> const& rhs)
     {
         return !(lhs == rhs);
     }

--- a/code/src/stf/include/interface/stf/geom/aabb.hpp
+++ b/code/src/stf/include/interface/stf/geom/aabb.hpp
@@ -120,20 +120,20 @@ namespace stf::geom
          * @brief Compute the diagonal of an @ref aabb
          * @return The diagonal vector of @p this
          */
-        inline vec_t const diagonal() const { return max - min; }
+        inline vec_t diagonal() const { return max - min; }
 
         /**
          * @brief Compute the center of an @ref aabb
          * @return The center point of @p this
          */
-        inline vec_t const center() const { return min + (math::constants<T>::half * diagonal()); }
+        inline vec_t center() const { return min + (math::constants<T>::half * diagonal()); }
 
         /**
          * @brief Compute whether a point is contained in an @ref aabb
          * @param [in] x
          * @return Whether or not @p x is contained in @p this
          */
-        bool const contains(vec_t const& x) const
+        bool contains(vec_t const& x) const
         {
             for (size_t i = 0; i < N; ++i)
             {
@@ -148,7 +148,7 @@ namespace stf::geom
          * @param [in] rhs
          * @return Whether or not @p rhs is contained in @p this
          */
-        bool const contains(aabb const& rhs) const
+        bool contains(aabb const& rhs) const
         {
             for (size_t i = 0; i < N; ++i)
             {
@@ -163,7 +163,7 @@ namespace stf::geom
          * @param [in] rhs
          * @return Whether or not @p this and @p rhs intersect
          */
-        bool const intersects(aabb const& rhs) const
+        bool intersects(aabb const& rhs) const
         {
             for (size_t i = 0; i < N; ++i)
             {
@@ -177,7 +177,7 @@ namespace stf::geom
          * @brief Compute the volume of a @ref aabb
          * @return The volume of @p this
          */
-        T const volume() const
+        T volume() const
         {
             T const delta = diagonal();
             T measure = math::constants<T>::one;
@@ -206,7 +206,7 @@ namespace stf::geom
          * @param [in] point
          * @return The square of the distance between @p this and @p point
          */
-        T const dist_squared(vec_t const& point) const
+        T dist_squared(vec_t const& point) const
         {
             if (contains(point))
             {
@@ -223,7 +223,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
         /**
          * @brief Scale an @ref aabb in place
@@ -347,7 +347,7 @@ namespace stf::geom
          * @brief Compute the number of vertices of the aabb
          * @return The number of vertices
          */
-        inline static size_t const vertex_count() { return 1 << N; }
+        inline static size_t vertex_count() { return 1 << N; }
 
         /**
          * @brief Compute the number of bytes allocated by @ref aabb
@@ -385,7 +385,7 @@ namespace stf::geom
      * @return A new bounding box that minimally encompasses @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    aabb<T, N> const fit(aabb<T, N> const& lhs, aabb<T, N> const& rhs)
+    aabb<T, N> fit(aabb<T, N> const& lhs, aabb<T, N> const& rhs)
     {
         return aabb<T, N>(lhs).fit(rhs);
     }
@@ -399,7 +399,7 @@ namespace stf::geom
      * @return The square of the distance between @p box and @p point
      */
     template<typename T, size_t N>
-    inline T const dist_squared(aabb<T, N> const& box, math::vec<T, N> const& point)
+    inline T dist_squared(aabb<T, N> const& box, math::vec<T, N> const& point)
     {
         return box.dist_squared(point);
     }
@@ -413,7 +413,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p box
      */
     template<typename T, size_t N>
-    inline T const dist_squared(math::vec<T, N> const& point, aabb<T, N> const& box)
+    inline T dist_squared(math::vec<T, N> const& point, aabb<T, N> const& box)
     {
         return dist_squared(box, point);
     }
@@ -427,7 +427,7 @@ namespace stf::geom
      * @return The distance between @p box and @p point
      */
     template<typename T, size_t N>
-    inline T const dist(aabb<T, N> const& box, math::vec<T, N> const& point)
+    inline T dist(aabb<T, N> const& box, math::vec<T, N> const& point)
     {
         return box.dist(point);
     }
@@ -441,7 +441,7 @@ namespace stf::geom
      * @return The distance between @p point and @p box
      */
     template<typename T, size_t N>
-    inline T const dist(math::vec<T, N> const& point, aabb<T, N> const& box)
+    inline T dist(math::vec<T, N> const& point, aabb<T, N> const& box)
     {
         return dist(box, point);
     }

--- a/code/src/stf/include/interface/stf/geom/holygon.hpp
+++ b/code/src/stf/include/interface/stf/geom/holygon.hpp
@@ -137,7 +137,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
         /**
          * @brief Translate a @ref holygon in place
@@ -222,7 +222,7 @@ namespace stf::geom
      * @return The square of the distance between @p shape and @p point
      */
     template<typename T>
-    inline T const dist_squared(holygon<T> const& shape, math::vec2<T> const& point)
+    inline T dist_squared(holygon<T> const& shape, math::vec2<T> const& point)
     {
         return shape.dist_squared(point);
     }
@@ -236,7 +236,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p shape
      */
     template<typename T>
-    inline T const dist_squared(math::vec2<T> const& point, holygon<T> const& shape)
+    inline T dist_squared(math::vec2<T> const& point, holygon<T> const& shape)
     {
         return dist_squared(shape, point);
     }
@@ -250,7 +250,7 @@ namespace stf::geom
      * @return The distance between @p shape and @p point
      */
     template<typename T>
-    inline T const dist(holygon<T> const& shape, math::vec2<T> const& point)
+    inline T dist(holygon<T> const& shape, math::vec2<T> const& point)
     {
         return shape.dist(point);
     }
@@ -264,7 +264,7 @@ namespace stf::geom
      * @return The distance between @p point and @p shape
      */
     template<typename T>
-    inline T const dist(math::vec2<T> const& point, holygon<T> const& shape)
+    inline T dist(math::vec2<T> const& point, holygon<T> const& shape)
     {
         return dist(shape, point);
     }

--- a/code/src/stf/include/interface/stf/geom/hyperplane.hpp
+++ b/code/src/stf/include/interface/stf/geom/hyperplane.hpp
@@ -134,7 +134,7 @@ namespace stf::geom
      * @return The distance between @p plane and @p point
      */
     template<typename T, size_t N>
-    inline T const dist(hyperplane<T, N> const& plane, math::vec<T, N> const& point)
+    inline T dist(hyperplane<T, N> const& plane, math::vec<T, N> const& point)
     {
         return plane.dist(point);
     }
@@ -148,7 +148,7 @@ namespace stf::geom
      * @return The distance between @p point and @p plane
      */
     template<typename T, size_t N>
-    inline T const dist(math::vec<T, N> const& point, hyperplane<T, N> const& plane)
+    inline T dist(math::vec<T, N> const& point, hyperplane<T, N> const& plane)
     {
         return dist(plane, point);
     }
@@ -162,7 +162,7 @@ namespace stf::geom
      * @return The distance between @p ring and @p point
      */
     template<typename T, size_t N>
-    inline T const signed_dist(hyperplane<T, N> const& plane, math::vec<T, N> const& point)
+    inline T signed_dist(hyperplane<T, N> const& plane, math::vec<T, N> const& point)
     {
         return plane.signed_dist(point);
     }
@@ -176,7 +176,7 @@ namespace stf::geom
      * @return The distance between @p point and @p plane
      */
     template<typename T, size_t N>
-    inline T const signed_dist(math::vec<T, N> const& point, hyperplane<T, N> const& plane)
+    inline T signed_dist(math::vec<T, N> const& point, hyperplane<T, N> const& plane)
     {
         return signed_dist(plane, point);
     }

--- a/code/src/stf/include/interface/stf/geom/obb.hpp
+++ b/code/src/stf/include/interface/stf/geom/obb.hpp
@@ -120,7 +120,7 @@ namespace stf::geom
          * @param [in] point
          * @return Whether or not @p point is contained in @p this
          */
-        bool const contains(vec_t const& point) const
+        bool contains(vec_t const& point) const
         {
             for (size_t d = 0; d < N; ++d)
             {
@@ -139,7 +139,7 @@ namespace stf::geom
          * @param [in] rhs
          * @return Whether or not @p rhs is contained in @p this
          */
-        bool const contains(obb const& rhs) const
+        bool contains(obb const& rhs) const
         {
             for (size_t v = 0; v < obb::vertex_count(); ++v)
             {
@@ -219,7 +219,7 @@ namespace stf::geom
          * @param [in] points
          * @return An @ref obb that minimally encompasses @p points
          */
-        static obb const fit(basis_t const& basis, std::vector<vec_t> const& points)
+        static obb fit(basis_t const& basis, std::vector<vec_t> const& points)
         {
             obb box = obb(basis);
             for (vec_t const& point : points)
@@ -233,13 +233,13 @@ namespace stf::geom
          * @brief Compute the number of vertices of the obb
          * @return The number of vertices
          */
-        inline static size_t const vertex_count() { return 1 << N; }
+        inline static size_t vertex_count() { return 1 << N; }
 
         /**
          * @brief Compute the number of bytes allocated by @ref obb
          * @return The byte count
          */
-        inline static size_t const byte_count() { return (2 + N) * vec_t::byte_count(); }
+        inline static size_t byte_count() { return (2 + N) * vec_t::byte_count(); }
 
     private:
 
@@ -279,7 +279,7 @@ namespace stf::geom
      * @note @p axis is assumed to be a unit vector
      */
     template<typename T, size_t N>
-    bool const separates(math::vec<T, N> const& axis, obb<T, N> const& lhs, obb<T, N> const& rhs)
+    bool separates(math::vec<T, N> const& axis, obb<T, N> const& lhs, obb<T, N> const& rhs)
     {
         math::interval<T> l = lhs.projection(axis);
         math::interval<T> r = rhs.projection(axis);
@@ -294,7 +294,7 @@ namespace stf::geom
      * @return Whether or not @p lhs intersects @p rhs
      */
     template<typename T>
-    bool const intersect(obb2<T> const& lhs, obb2<T> const& rhs)
+    bool intersect(obb2<T> const& lhs, obb2<T> const& rhs)
     {
         // intersection is computed using the separating axis test. if two 2d obbs do not intersect, then the set of edge
         // normals will contain a separating axis
@@ -323,7 +323,7 @@ namespace stf::geom
      * @return Whether or not @p lhs intersects @p rhs
      */
     template<typename T>
-    bool const intersect(obb3<T> const& lhs, obb3<T> const& rhs)
+    bool intersect(obb3<T> const& lhs, obb3<T> const& rhs)
     {
         // intersection is computed using the separating axis test. if two 3d obbs do not intersect, then the union of the
         // following two sets will contain a separating axis

--- a/code/src/stf/include/interface/stf/geom/polygon.hpp
+++ b/code/src/stf/include/interface/stf/geom/polygon.hpp
@@ -256,7 +256,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
         /**
          * @brief Compute the signed distance from a query point to the boundary of a @ref polygon
@@ -352,7 +352,7 @@ namespace stf::geom
      * @return The square of the distance between @p ring and @p point
      */
     template<typename T>
-    inline T const dist_squared(polygon<T> const& ring, math::vec2<T> const& point)
+    inline T dist_squared(polygon<T> const& ring, math::vec2<T> const& point)
     {
         return ring.dist_squared(point);
     }
@@ -366,7 +366,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p ring
      */
     template<typename T>
-    inline T const dist_squared(math::vec2<T> const& point, polygon<T> const& ring)
+    inline T dist_squared(math::vec2<T> const& point, polygon<T> const& ring)
     {
         return dist_squared(ring, point);
     }
@@ -380,7 +380,7 @@ namespace stf::geom
      * @return The distance between @p ring and @p point
      */
     template<typename T>
-    inline T const dist(polygon<T> const& ring, math::vec2<T> const& point)
+    inline T dist(polygon<T> const& ring, math::vec2<T> const& point)
     {
         return ring.dist(point);
     }
@@ -394,7 +394,7 @@ namespace stf::geom
      * @return The distance between @p point and @p ring
      */
     template<typename T>
-    inline T const dist(math::vec2<T> const& point, polygon<T> const& ring)
+    inline T dist(math::vec2<T> const& point, polygon<T> const& ring)
     {
         return dist(ring, point);
     }
@@ -408,7 +408,7 @@ namespace stf::geom
      * @return The distance between @p ring and @p point
      */
     template<typename T>
-    inline T const signed_dist(polygon<T> const& ring, math::vec2<T> const& point)
+    inline T signed_dist(polygon<T> const& ring, math::vec2<T> const& point)
     {
         return ring.signed_dist(point);
     }
@@ -422,7 +422,7 @@ namespace stf::geom
      * @return The distance between @p point and @p ring
      */
     template<typename T>
-    inline T const signed_dist(math::vec2<T> const& point, polygon<T> const& ring)
+    inline T signed_dist(math::vec2<T> const& point, polygon<T> const& ring)
     {
         return signed_dist(ring, point);
     }

--- a/code/src/stf/include/interface/stf/geom/polyline.hpp
+++ b/code/src/stf/include/interface/stf/geom/polyline.hpp
@@ -160,7 +160,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
         /**
          * @brief Interpolate along a @ref polyline
@@ -295,7 +295,7 @@ namespace stf::geom
      * @return The square of the distance between @p linestring and @p point
      */
     template<typename T, size_t N>
-    inline T const dist_squared(polyline<T, N> const& linestring, math::vec<T, N> const& point)
+    inline T dist_squared(polyline<T, N> const& linestring, math::vec<T, N> const& point)
     {
         return linestring.dist_squared(point);
     }
@@ -309,7 +309,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p linestring
      */
     template<typename T, size_t N>
-    inline T const dist_squared(math::vec<T, N> const& point, polyline<T, N> const& linestring)
+    inline T dist_squared(math::vec<T, N> const& point, polyline<T, N> const& linestring)
     {
         return dist_squared(linestring, point);
     }
@@ -323,7 +323,7 @@ namespace stf::geom
      * @return The distance between @p linestring and @p point
      */
     template<typename T, size_t N>
-    inline T const dist(polyline<T, N> const& linestring, math::vec<T, N> const& point)
+    inline T dist(polyline<T, N> const& linestring, math::vec<T, N> const& point)
     {
         return linestring.dist(point);
     }
@@ -337,7 +337,7 @@ namespace stf::geom
      * @return The distance between @p point and @p linestring
      */
     template<typename T, size_t N>
-    inline T const dist(math::vec<T, N> const& point, polyline<T, N> const& linestring)
+    inline T dist(math::vec<T, N> const& point, polyline<T, N> const& linestring)
     {
         return dist(linestring, point);
     }

--- a/code/src/stf/include/interface/stf/geom/ray.hpp
+++ b/code/src/stf/include/interface/stf/geom/ray.hpp
@@ -53,14 +53,14 @@ namespace stf::geom
          * @brief Compute a normalized ray
          * @return A normalized ray in the direction of @p this
          */
-        inline ray const normalized() const { return ray(*this).normalize(); }
+        inline ray normalized() const { return ray(*this).normalize(); }
 
         /**
          * @brief Compute the square of the distance between a ray and a vector
          * @param [in] query
          * @return The square of the distance between @p this and @p point
          */
-        T const dist_squared(vec_t const& query) const
+        T dist_squared(vec_t const& query) const
         {
             vec_t unit_dir = direction.normalized();
             T scalar = math::dot(query - point, unit_dir);
@@ -74,7 +74,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
     };
 
@@ -106,7 +106,7 @@ namespace stf::geom
      * @return The square of the distance between @p beam and @p point
      */
     template<typename T, size_t N>
-    inline T const dist_squared(ray<T, N> const& beam, math::vec<T, N> const& point)
+    inline T dist_squared(ray<T, N> const& beam, math::vec<T, N> const& point)
     {
         return beam.dist_squared(point);
     }
@@ -120,7 +120,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p beam
      */
     template<typename T, size_t N>
-    inline T const dist_squared(math::vec<T, N> const& point, ray<T, N> const& beam)
+    inline T dist_squared(math::vec<T, N> const& point, ray<T, N> const& beam)
     {
         return dist_squared(beam, point);
     }
@@ -134,7 +134,7 @@ namespace stf::geom
      * @return The distance between @p beam and @p point
      */
     template<typename T, size_t N>
-    inline T const dist(ray<T, N> const& beam, math::vec<T, N> const& point)
+    inline T dist(ray<T, N> const& beam, math::vec<T, N> const& point)
     {
         return beam.dist(point);
     }
@@ -148,7 +148,7 @@ namespace stf::geom
      * @return The distance between @p point and @p beam
      */
     template<typename T, size_t N>
-    inline T const dist(math::vec<T, N> const& point, ray<T, N> const& beam)
+    inline T dist(math::vec<T, N> const& point, ray<T, N> const& beam)
     {
         return dist(beam, point);
     }

--- a/code/src/stf/include/interface/stf/geom/segment.hpp
+++ b/code/src/stf/include/interface/stf/geom/segment.hpp
@@ -112,7 +112,7 @@ namespace stf::geom
          * @param [in] point
          * @return The square of the distance between @p this and @p point
          */
-        T const dist_squared(vec_t const& point) const
+        T dist_squared(vec_t const& point) const
         {
             vec_t diff = delta();
             T scalar = math::dot(point - a, diff) / math::dot(diff, diff);
@@ -126,7 +126,7 @@ namespace stf::geom
          * @param [in] point
          * @return The distance between @p this and @p point
          */
-        inline T const dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
+        inline T dist(vec_t const& point) const { return std::sqrt(dist_squared(point)); }
 
         /**
          * @brief Interpolate along the semgent
@@ -174,7 +174,7 @@ namespace stf::geom
      * @return Whether or not @p lhs and @p rhs are approximately equal
      */
     template<typename T, size_t N>
-    inline bool const operator==(segment<T, N> const& lhs, segment<T, N> const& rhs)
+    inline bool operator==(segment<T, N> const& lhs, segment<T, N> const& rhs)
     {
         return lhs.a == rhs.a && lhs.b == rhs.b;
     }
@@ -188,7 +188,7 @@ namespace stf::geom
      * @return Whether or not @p lhs and @p rhs are approximately not equal
      */
     template<typename T, size_t N>
-    inline bool const operator!=(segment<T, N> const& lhs, segment<T, N> const& rhs)
+    inline bool operator!=(segment<T, N> const& lhs, segment<T, N> const& rhs)
     {
         return !(lhs == rhs);
     }
@@ -202,7 +202,7 @@ namespace stf::geom
      * @return The square of the distance between @p seg and @p point
      */
     template<typename T, size_t N>
-    inline T const dist_squared(segment<T, N> const& seg, math::vec<T, N> const& point)
+    inline T dist_squared(segment<T, N> const& seg, math::vec<T, N> const& point)
     {
         return seg.dist_squared(point);
     }
@@ -216,7 +216,7 @@ namespace stf::geom
      * @return The square of the distance between @p point and @p seg
      */
     template<typename T, size_t N>
-    inline T const dist_squared(math::vec<T, N> const& point, segment<T, N> const& seg)
+    inline T dist_squared(math::vec<T, N> const& point, segment<T, N> const& seg)
     {
         return dist_squared(seg, point);
     }
@@ -230,7 +230,7 @@ namespace stf::geom
      * @return The distance between @p seg and @p point
      */
     template<typename T, size_t N>
-    inline T const dist(segment<T, N> const& seg, math::vec<T, N> const& point)
+    inline T dist(segment<T, N> const& seg, math::vec<T, N> const& point)
     {
         return seg.dist(point);
     }
@@ -244,7 +244,7 @@ namespace stf::geom
      * @return The distance between @p point and @p seg
      */
     template<typename T, size_t N>
-    inline T const dist(math::vec<T, N> const& point, segment<T, N> const& seg)
+    inline T dist(math::vec<T, N> const& point, segment<T, N> const& seg)
     {
         return dist(seg, point);
     }

--- a/code/src/stf/include/interface/stf/gfx/color.hpp
+++ b/code/src/stf/include/interface/stf/gfx/color.hpp
@@ -178,7 +178,7 @@ namespace stf::gfx
      * @param [in] eps The epsilon distance to use when computating approximate equality
      * @return Whether or not @p lhs and @p rhs are closer than @p eps
      */
-    inline bool const equ(rgba const& lhs, rgba const& rhs, float eps)
+    inline bool equ(rgba const& lhs, rgba const& rhs, float eps)
     {
         return equ(static_cast<math::vec4<float>>(lhs), static_cast<math::vec4<float>>(rhs), eps);
     }
@@ -190,7 +190,7 @@ namespace stf::gfx
      * @param [in] eps The epsilon distance to use when computating approximate equality
      * @return Whether or not @p lhs and @p rhs are further apart than @p eps
      */
-    inline bool const neq(rgba const& lhs, rgba const& rhs, float eps)
+    inline bool neq(rgba const& lhs, rgba const& rhs, float eps)
     {
         return !equ(lhs, rhs, eps);
     }
@@ -201,7 +201,7 @@ namespace stf::gfx
      * @param [in] rhs
      * @return Whether or not @p lhs and @p rhs are approximately equal
      */
-    inline bool const operator==(rgba const& lhs, rgba const& rhs)
+    inline bool operator==(rgba const& lhs, rgba const& rhs)
     {
         return equ(lhs, rhs, math::constants<float>::tol);
     }
@@ -212,7 +212,7 @@ namespace stf::gfx
      * @param [in] rhs
      * @return Whether or not @p lhs and @p rhs are approximately not equal
      */
-    inline bool const operator!=(rgba const& lhs, rgba const& rhs)
+    inline bool operator!=(rgba const& lhs, rgba const& rhs)
     {
         return !(lhs == rhs);
     }

--- a/code/src/stf/include/interface/stf/math/basis.hpp
+++ b/code/src/stf/include/interface/stf/math/basis.hpp
@@ -29,7 +29,7 @@ namespace stf::math
      * @return The canonical basis of R^n
      */
     template<typename T, size_t N>
-    basis<T, N> const canonical_basis()
+    basis<T, N> canonical_basis()
     {
         basis<T, N> ret;
         for (size_t d = 0; d < N; ++d)
@@ -48,7 +48,7 @@ namespace stf::math
      * @note @p rotation is assumed to be orthonormal
      */
     template<typename T, size_t N>
-    basis<T, N> const to_basis(mtx<T, N> const& rotation)
+    basis<T, N> to_basis(mtx<T, N> const& rotation)
     {
         basis<T, N> ret;
         for (size_t d = 0; d < N; ++d)

--- a/code/src/stf/include/interface/stf/math/matrix.hpp
+++ b/code/src/stf/include/interface/stf/math/matrix.hpp
@@ -32,7 +32,7 @@ namespace stf::math
              * @param [in] _m
              * @param [in] _c
              */
-            col_proxy(mtx const& _m, size_t _c) : m(_m), c(_c) {}
+            const_col_proxy(mtx const& _m, size_t _c) : m(_m), c(_c) {}
 
             /**
              * @brief Const access to a single scalar in the column
@@ -105,7 +105,7 @@ namespace stf::math
             /**
              * @brief Conversion operator from a @ref col_proxy to a @ref const_col_proxy
              */
-            inline operator vec<T, N>() const { return const_col_proxy(m, c); }
+            inline operator const_col_proxy() const { return const_col_proxy(m, c); }
 
             /**
              * @brief Conversion operator from a @ref col_proxy to a @ref vec

--- a/code/src/stf/include/interface/stf/math/matrix.hpp
+++ b/code/src/stf/include/interface/stf/math/matrix.hpp
@@ -84,8 +84,50 @@ namespace stf::math
         };
 
         /**
+         * @brief A proxy struct that gives const access to a single row of a @ref mtx
+         */
+        struct const_row_proxy
+        {
+
+            /**
+             * @brief Construct from a @ref mtx const reference and a row index
+             * @param [in] _m
+             * @param [in] _r
+             */
+            const_row_proxy(mtx const& _m, size_t _r) : m(_m), r(_r) {}
+
+            /**
+             * @brief Const access to a single scalar in the row
+             * @param [in] j The index of the column
+             * @return A const reference to the scalar
+             */
+            inline T const& operator[](size_t j) const { return m.values[r + j * N]; }
+
+            /**
+             * @brief Cast a @ref const_row_proxy to a @ref vec
+             */
+            inline operator vec<T, N>() const
+            {
+                vec<T, N> vec;
+                for (size_t j = 0; j < N; ++j) { vec[j] = (*this)[j]; }
+                return vec;
+            }
+
+            /**
+             * @brief Cast a @ref const_row_proxy to a @ref vec
+             * @return The row proxy as a vector
+             */
+            inline vec<T, N> as_vec() const { return static_cast<vec<T, N>>(*this); }
+
+        private:
+
+            mtx const& m;
+            size_t r;
+
+        };
+
+        /**
          * @brief A proxy struct that gives access to a single row of a @ref mtx
-         * @todo make this struct non-copyable when const?
          */
         struct row_proxy
         {
@@ -123,7 +165,12 @@ namespace stf::math
             }
 
             /**
-             * @brief Cast a @ref row_proxy to a @ref vec
+             * @brief Conversion from @ref row_proxy to a @ref const_row_proxy
+             */
+            inline operator const_row_proxy() const { return const_row_proxy(m, r); }
+
+            /**
+             * @brief Conversion from @ref row_proxy to a @ref vec
              */
             inline operator vec<T, N>() const
             {
@@ -216,7 +263,7 @@ namespace stf::math
          * @param [in] i The index of the row
          * @return A proxy class that gives const access to the row
          */
-        inline row_proxy const row(size_t const i) const { return row_proxy(const_cast<mtx&>(*this), i); }
+        inline const_row_proxy row(size_t const i) const { return const_row_proxy(*this, i); }
 
         /**
          * @brief Access to a single row of the matrix
@@ -230,7 +277,7 @@ namespace stf::math
          * @param [in] i The index of the row
          * @return A proxy class that gives const access to the row
          */
-        inline row_proxy const operator[](size_t const i) const { return row(i); }
+        inline const_row_proxy operator[](size_t const i) const { return row(i); }
 
         /**
          * @brief Access to a single row of the matrix

--- a/code/src/stf/include/interface/stf/math/matrix.hpp
+++ b/code/src/stf/include/interface/stf/math/matrix.hpp
@@ -22,7 +22,8 @@ namespace stf::math
     {
 
         /**
-         * @brief A proxy class that gives access to a single column of a @ref mtx
+         * @brief A proxy struct that gives access to a single column of a @ref mtx
+         * @todo make this struct non-copyable when const?
          */
         struct col_proxy
         {
@@ -83,7 +84,8 @@ namespace stf::math
         };
 
         /**
-         * @brief A proxy class that gives access to a single row of a @ref mtx
+         * @brief A proxy struct that gives access to a single row of a @ref mtx
+         * @todo make this struct non-copyable when const?
          */
         struct row_proxy
         {
@@ -560,7 +562,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are approximately equal
      */
     template<typename T, size_t N>
-    inline bool const operator==(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
+    inline bool operator==(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
     {
         vec<T, N * N> lhs_as_vec = vec<T, N * N>(lhs.values);
         vec<T, N * N> rhs_as_vec = vec<T, N * N>(rhs.values);
@@ -576,7 +578,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are approximately not equal
      */
     template<typename T, size_t N>
-    inline bool const operator!=(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
+    inline bool operator!=(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
     {
         return !(lhs == rhs);
     }
@@ -590,7 +592,7 @@ namespace stf::math
      * @return The matrix result of the product between @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline mtx<T, N> const operator*(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
+    inline mtx<T, N> operator*(mtx<T, N> const& lhs, mtx<T, N> const& rhs)
     {
         return mtx<T, N>(lhs) *= rhs;
     }
@@ -604,7 +606,7 @@ namespace stf::math
      * @return The column vector result of the product between @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator*(mtx<T, N> const& lhs, vec<T, N> const& rhs)
+    inline vec<T, N> operator*(mtx<T, N> const& lhs, vec<T, N> const& rhs)
     {
         vec<T, N> result;
         for (size_t j = 0; j < N; ++j)
@@ -623,7 +625,7 @@ namespace stf::math
      * @return The rwo vector result of the product between @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator*(vec<T, N> const& lhs, mtx<T, N> const& rhs)
+    inline vec<T, N> operator*(vec<T, N> const& lhs, mtx<T, N> const& rhs)
     {
         vec<T, N> result;
         for (size_t i = 0; i < N; ++i)
@@ -642,7 +644,7 @@ namespace stf::math
      * @return The matrix @p rhs scaled by @p lhs
      */
     template<typename T, size_t N>
-    inline mtx<T, N> const operator*(T const lhs, mtx<T, N> const& rhs)
+    inline mtx<T, N> operator*(T const lhs, mtx<T, N> const& rhs)
     {
         return mtx<T, N>(rhs) *= lhs;
     }
@@ -656,7 +658,7 @@ namespace stf::math
      * @return The matrix @p lhs scaled by @p rhs
      */
     template<typename T, size_t N>
-    inline mtx<T, N> const operator*(mtx<T, N> const& lhs, T const rhs)
+    inline mtx<T, N> operator*(mtx<T, N> const& lhs, T const rhs)
     {
         return rhs * lhs;
     }

--- a/code/src/stf/include/interface/stf/math/matrix.hpp
+++ b/code/src/stf/include/interface/stf/math/matrix.hpp
@@ -22,8 +22,50 @@ namespace stf::math
     {
 
         /**
+         * @brief A proxy struct that gives const access to a single column of a @ref mtx
+         */
+        struct const_col_proxy
+        {
+
+            /**
+             * @brief Construct from a @ref mtx const reference and a column index
+             * @param [in] _m
+             * @param [in] _c
+             */
+            col_proxy(mtx const& _m, size_t _c) : m(_m), c(_c) {}
+
+            /**
+             * @brief Const access to a single scalar in the column
+             * @param [in] i The index of the row
+             * @return A const reference to the scalar
+             */
+            inline T const& operator[](size_t i) const { return m.values[c * N + i]; }
+
+            /**
+             * @brief Conversion operator from a @ref col_proxy to a @ref vec
+             */
+            inline operator vec<T, N>() const
+            {
+                vec<T, N> vec;
+                for (size_t i = 0; i < N; ++i) { vec[i] = (*this)[i]; }
+                return vec;
+            }
+
+            /**
+             * @brief Convert a @ref col_proxy to a @ref vec
+             * @return The column proxy as a vector
+             */
+            inline vec<T, N> as_vec() const { return static_cast<vec<T, N>>(*this); }
+
+        private:
+
+            mtx const& m;
+            size_t c;
+
+        };
+
+        /**
          * @brief A proxy struct that gives access to a single column of a @ref mtx
-         * @todo make this struct non-copyable when const?
          */
         struct col_proxy
         {
@@ -61,7 +103,12 @@ namespace stf::math
             }
 
             /**
-             * @brief Cast a @ref col_proxy to a @ref vec
+             * @brief Conversion operator from a @ref col_proxy to a @ref const_col_proxy
+             */
+            inline operator vec<T, N>() const { return const_col_proxy(m, c); }
+
+            /**
+             * @brief Conversion operator from a @ref col_proxy to a @ref vec
              */
             inline operator vec<T, N>() const
             {
@@ -71,7 +118,7 @@ namespace stf::math
             }
 
             /**
-             * @brief Cast a @ref col_proxy to a @ref vec
+             * @brief Convert a @ref col_proxy to a @ref vec
              * @return The column proxy as a vector
              */
             inline vec<T, N> as_vec() const { return static_cast<vec<T, N>>(*this); }
@@ -104,7 +151,7 @@ namespace stf::math
             inline T const& operator[](size_t j) const { return m.values[r + j * N]; }
 
             /**
-             * @brief Cast a @ref const_row_proxy to a @ref vec
+             * @brief Conversion operator from a @ref const_row_proxy to a @ref vec
              */
             inline operator vec<T, N>() const
             {
@@ -114,7 +161,7 @@ namespace stf::math
             }
 
             /**
-             * @brief Cast a @ref const_row_proxy to a @ref vec
+             * @brief Convert a @ref const_row_proxy to a @ref vec
              * @return The row proxy as a vector
              */
             inline vec<T, N> as_vec() const { return static_cast<vec<T, N>>(*this); }
@@ -165,12 +212,12 @@ namespace stf::math
             }
 
             /**
-             * @brief Conversion from @ref row_proxy to a @ref const_row_proxy
+             * @brief Conversion operator from a @ref row_proxy to a @ref const_row_proxy
              */
             inline operator const_row_proxy() const { return const_row_proxy(m, r); }
 
             /**
-             * @brief Conversion from @ref row_proxy to a @ref vec
+             * @brief Conversion operator from a @ref row_proxy to a @ref vec
              */
             inline operator vec<T, N>() const
             {
@@ -180,7 +227,7 @@ namespace stf::math
             }
 
             /**
-             * @brief Cast a @ref row_proxy to a @ref vec
+             * @brief Convert a @ref row_proxy to a @ref vec
              * @return The row proxy as a vector
              */
             inline vec<T, N> as_vec() const { return static_cast<vec<T, N>>(*this); }
@@ -249,7 +296,7 @@ namespace stf::math
          * @param [in] j The index of the column
          * @return A proxy class that gives const access to the column
          */
-        inline col_proxy const col(size_t const j) const { return col_proxy(const_cast<mtx&>(*this), j); }
+        inline const_col_proxy col(size_t const j) const { return const_col_proxy(*this, j); }
 
         /**
          * @brief Access to a single column of the matrix

--- a/code/src/stf/include/interface/stf/math/scalar.hpp
+++ b/code/src/stf/include/interface/stf/math/scalar.hpp
@@ -19,7 +19,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are less than or equal to @p eps apart
      */
     template<typename T>
-    inline bool const equ(T const lhs, T const rhs, T const eps)
+    inline bool equ(T const lhs, T const rhs, T const eps)
     {
         return (std::abs(lhs - rhs) <= eps) ? true : false;
     }
@@ -33,7 +33,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are greater than @p eps apart
      */
     template<typename T>
-    inline bool const neq(T const lhs, T const rhs, T const eps)
+    inline bool neq(T const lhs, T const rhs, T const eps)
     {
         return !equ(lhs, rhs, eps);
     }

--- a/code/src/stf/include/interface/stf/math/vector.hpp
+++ b/code/src/stf/include/interface/stf/math/vector.hpp
@@ -144,7 +144,7 @@ namespace stf::math
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const dot(vec const& rhs) const { return raw::dot<T, N>(values, rhs.values); }
+        inline T dot(vec const& rhs) const { return raw::dot<T, N>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
@@ -310,7 +310,7 @@ namespace stf::math
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const dot(vec const& rhs) const { return raw::dot<T, 2>(values, rhs.values); }
+        inline T dot(vec const& rhs) const { return raw::dot<T, 2>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
@@ -483,7 +483,7 @@ namespace stf::math
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const dot(vec const& rhs) const { return raw::dot<T, 3>(values, rhs.values); }
+        inline T dot(vec const& rhs) const { return raw::dot<T, 3>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
@@ -673,7 +673,7 @@ namespace stf::math
          * @param [in] rhs
          * @return The dot product of @p this with @p rhs
          */
-        inline T const dot(vec const& rhs) const { return raw::dot<T, 4>(values, rhs.values); }
+        inline T dot(vec const& rhs) const { return raw::dot<T, 4>(values, rhs.values); }
 
         /**
          * @brief Compute the square of the length of a vector
@@ -769,7 +769,7 @@ namespace stf::math
      * @return A normalized vector in the direction of @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const normalized(vec<T, N> const& rhs)
+    inline vec<T, N> normalized(vec<T, N> const& rhs)
     {
         return rhs.normalized();
     }
@@ -812,7 +812,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are closer than @p eps
      */
     template<typename T, size_t N>
-    inline bool const equ(vec<T, N> const& lhs, vec<T, N> const& rhs, T const eps)
+    inline bool equ(vec<T, N> const& lhs, vec<T, N> const& rhs, T const eps)
     {
         return (dist(lhs, rhs) <= eps) ? true : false;
     }
@@ -827,7 +827,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are further apart than @p eps
      */
     template<typename T, size_t N>
-    inline bool const neq(vec<T, N> const& lhs, vec<T, N> const& rhs, T eps)
+    inline bool neq(vec<T, N> const& lhs, vec<T, N> const& rhs, T eps)
     {
         return !equ(lhs, rhs, eps);
     }
@@ -841,7 +841,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are approximately equal
      */
     template<typename T, size_t N>
-    inline bool const operator==(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline bool operator==(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return equ(lhs, rhs, constants<T>::tol);
     }
@@ -855,7 +855,7 @@ namespace stf::math
      * @return Whether or not @p lhs and @p rhs are approximately not equal
      */
     template<typename T, size_t N>
-    inline bool const operator!=(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline bool operator!=(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return !(lhs == rhs);
     }
@@ -868,7 +868,7 @@ namespace stf::math
      * @return The negative of @p lhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator-(vec<T, N> const& lhs)
+    inline vec<T, N> operator-(vec<T, N> const& lhs)
     {
         vec<T, N> result;
         for (size_t i = 0; i < N; ++i)
@@ -887,7 +887,7 @@ namespace stf::math
      * @return The sum of @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator+(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline vec<T, N> operator+(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return vec<T, N>(lhs) += rhs;
     }
@@ -901,7 +901,7 @@ namespace stf::math
      * @return The difference of @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator-(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline vec<T, N> operator-(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return vec<T, N>(lhs) -= rhs;
     }
@@ -915,7 +915,7 @@ namespace stf::math
      * @return @p lhs scaled by @p scalar
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator*(vec<T, N> const& lhs, T const scalar)
+    inline vec<T, N> operator*(vec<T, N> const& lhs, T const scalar)
     {
         return vec<T, N>(lhs) *= scalar;
     }
@@ -929,7 +929,7 @@ namespace stf::math
      * @return @p rhs scaled by @p scalar
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator*(T const scalar, vec<T, N> const& rhs)
+    inline vec<T, N> operator*(T const scalar, vec<T, N> const& rhs)
     {
         return rhs * scalar;
     }
@@ -943,7 +943,7 @@ namespace stf::math
      * @return @p lhs divided by @p scalar
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator/(vec<T, N> const& lhs, T const scalar)
+    inline vec<T, N> operator/(vec<T, N> const& lhs, T const scalar)
     {
         T factor = constants<T>::one / scalar;
         return factor * lhs;
@@ -958,7 +958,7 @@ namespace stf::math
      * @return @p scalar divided by @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator/(T const scalar, vec<T, N> const& rhs)
+    inline vec<T, N> operator/(T const scalar, vec<T, N> const& rhs)
     {
         vec<T, N> result;
         for (size_t i = 0; i < N; ++i)
@@ -977,7 +977,7 @@ namespace stf::math
      * @return The dot product of @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline T const dot(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline T dot(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return raw::dot<T, N>(lhs.values, rhs.values);
     }
@@ -995,7 +995,7 @@ namespace stf::math
      * @return The 2D cross product of @p lhs and @p rhs 
      */
     template<typename T>
-    inline T const cross(vec2<T> const& lhs, vec2<T> const& rhs)
+    inline T cross(vec2<T> const& lhs, vec2<T> const& rhs)
     {
         return lhs.x * rhs.y - lhs.y * rhs.x;
     }
@@ -1009,7 +1009,7 @@ namespace stf::math
      * @return The 3D cross product of @p lhs and @p rhs
      */
     template<typename T>
-    inline vec3<T> const cross(vec3<T> const& lhs, vec3<T> const& rhs)
+    inline vec3<T> cross(vec3<T> const& lhs, vec3<T> const& rhs)
     {
         return vec3<T>
         (
@@ -1035,7 +1035,7 @@ namespace stf::math
      * @return The orientation of @p p, @p q, and @p r
      */
     template<typename T>
-    inline T const orientation(vec2<T> const& p, vec2<T> const& q, vec2<T> const& r)
+    inline T orientation(vec2<T> const& p, vec2<T> const& q, vec2<T> const& r)
     {
         return cross(q - p, r - p);
     }
@@ -1052,7 +1052,7 @@ namespace stf::math
      * @return The hadamard product of @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const hadamard(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline vec<T, N> hadamard(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return vec<T, N>(lhs) *= (rhs);
     }
@@ -1069,7 +1069,7 @@ namespace stf::math
      * @return The hadamard product of @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline vec<T, N> const operator*(vec<T, N> const& lhs, vec<T, N> const& rhs) { return hadamard(lhs, rhs); }
+    inline vec<T, N> operator*(vec<T, N> const& lhs, vec<T, N> const& rhs) { return hadamard(lhs, rhs); }
 
     /**
      * @brief Compute the prefix of a vector

--- a/code/src/stf/include/interface/stf/math/vector.hpp
+++ b/code/src/stf/include/interface/stf/math/vector.hpp
@@ -783,7 +783,7 @@ namespace stf::math
      * @return The square of the distance between @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline T const dist_squared(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline T dist_squared(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return (lhs - rhs).length_squared();
     }
@@ -797,7 +797,7 @@ namespace stf::math
      * @return The distance between @p lhs and @p rhs
      */
     template<typename T, size_t N>
-    inline T const dist(vec<T, N> const& lhs, vec<T, N> const& rhs)
+    inline T dist(vec<T, N> const& lhs, vec<T, N> const& rhs)
     {
         return (lhs - rhs).length();
     }

--- a/code/tests/stf/include/private/stf/alg/scaffolding/clipping.hpp
+++ b/code/tests/stf/include/private/stf/alg/scaffolding/clipping.hpp
@@ -11,10 +11,10 @@ namespace stf::alg::scaffolding::clipping
     template<typename T>
     struct segment
     {
-        geom::aabb2<T> const box;
-        geom::segment2<T> const input;
-        bool const accept;
-        geom::segment2<T> const clipped;
+        geom::aabb2<T> box;
+        geom::segment2<T> input;
+        bool accept;
+        geom::segment2<T> clipped;
     };
 
     template<typename T>
@@ -33,9 +33,9 @@ namespace stf::alg::scaffolding::clipping
     template<typename T>
     struct polyline
     {
-        geom::aabb2<T> const box;
-        geom::polyline2<T> const input;
-        std::vector<geom::polyline2<T>> const clipped;
+        geom::aabb2<T> box;
+        geom::polyline2<T> input;
+        std::vector<geom::polyline2<T>> clipped;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/alg/scaffolding/intersect.hpp
+++ b/code/tests/stf/include/private/stf/alg/scaffolding/intersect.hpp
@@ -11,9 +11,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct segment_with_segment
     {
-        geom::segment2<T> const lhs;
-        geom::segment2<T> const rhs;
-        bool const expected;
+        geom::segment2<T> lhs;
+        geom::segment2<T> rhs;
+        bool expected;
     };
 
     template<typename T>
@@ -38,9 +38,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct segment_with_aabb
     {
-        geom::segment2<T> const seg;
-        geom::aabb2<T> const box;
-        bool const expected;
+        geom::segment2<T> seg;
+        geom::aabb2<T> box;
+        bool expected;
     };
 
     template<typename T>
@@ -58,9 +58,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct polyline_with_aabb
     {
-        geom::polyline2<T> const polyline;
-        geom::aabb2<T> const box;
-        bool const expected;
+        geom::polyline2<T> polyline;
+        geom::aabb2<T> box;
+        bool expected;
     };
 
     template<typename T>
@@ -73,9 +73,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct polygon_with_aabb
     {
-        geom::polygon<T> const polygon;
-        geom::aabb2<T> const box;
-        bool const expected;
+        geom::polygon<T> polygon;
+        geom::aabb2<T> box;
+        bool expected;
     };
 
     template<typename T>
@@ -88,9 +88,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct polygon_with_segment
     {
-        geom::polygon<T> const polygon;
-        geom::segment2<T> const segment;
-        bool const expected;
+        geom::polygon<T> polygon;
+        geom::segment2<T> segment;
+        bool expected;
     };
 
     template<typename T>
@@ -103,9 +103,9 @@ namespace stf::alg::scaffolding::intersect
     template<typename T>
     struct polygon_with_polyline
     {
-        geom::polygon<T> const polygon;
-        geom::polyline2<T> const polyline;
-        bool const expected;
+        geom::polygon<T> polygon;
+        geom::polyline2<T> polyline;
+        bool expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/alg/scaffolding/statistics.hpp
+++ b/code/tests/stf/include/private/stf/alg/scaffolding/statistics.hpp
@@ -11,8 +11,8 @@ namespace stf::alg::scaffolding::statistics
     template<typename T>
     struct median
     {
-        std::vector<T> const values;
-        T const expected;
+        std::vector<T> values;
+        T expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/alg/scaffolding/tessellation.hpp
+++ b/code/tests/stf/include/private/stf/alg/scaffolding/tessellation.hpp
@@ -11,10 +11,10 @@ namespace stf::alg::scaffolding::tessellation
     template<typename T>
     struct polyline_via_length
     {
-        geom::polyline2<T> const polyline;
-        T const max_len;
-        bool const loop;
-        std::vector<math::vec2<T>> const expected;
+        geom::polyline2<T> polyline;
+        T max_len;
+        bool loop;
+        std::vector<math::vec2<T>> expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/cam/scaffolding/frustum.hpp
+++ b/code/tests/stf/include/private/stf/cam/scaffolding/frustum.hpp
@@ -13,9 +13,9 @@ namespace stf::cam::scaffolding::frustum
     template<typename T>
     struct contains
     {
-        cam::frustum<T> const frustum;
-        geom::aabb3<T> const box;
-        bool const contains;
+        cam::frustum<T> frustum;
+        geom::aabb3<T> box;
+        bool contains;
     };
 
     template<typename T>
@@ -28,9 +28,9 @@ namespace stf::cam::scaffolding::frustum
     template<typename T>
     struct intersects_fast
     {
-        cam::frustum<T> const frustum;
-        geom::aabb3<T> const box;
-        bool const intersects;
+        cam::frustum<T> frustum;
+        geom::aabb3<T> box;
+        bool intersects;
     };
 
     template<typename T>
@@ -44,9 +44,9 @@ namespace stf::cam::scaffolding::frustum
     template<typename T>
     struct intersects
     {
-        cam::frustum<T> const frustum;
-        geom::aabb3<T> const box;
-        bool const intersects;
+        cam::frustum<T> frustum;
+        geom::aabb3<T> box;
+        bool intersects;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/cam/scaffolding/scamera.hpp
+++ b/code/tests/stf/include/private/stf/cam/scaffolding/scamera.hpp
@@ -11,10 +11,10 @@ namespace stf::cam::scaffolding::scamera
     template<typename T>
     struct direction_vectors
     {
-        cam::scamera<T> const camera;
-        math::vec3<T> const look;
-        math::vec3<T> const up;
-        math::vec3<T> const right;
+        cam::scamera<T> camera;
+        math::vec3<T> look;
+        math::vec3<T> up;
+        math::vec3<T> right;
     };
 
     template<typename T>
@@ -28,11 +28,11 @@ namespace stf::cam::scaffolding::scamera
     template<typename T>
     struct orbit
     {
-        cam::scamera<T> const initial;
-        math::vec3<T> const focus;
-        T const delta_phi;
-        T const delta_theta;
-        cam::scamera<T> const expected;
+        cam::scamera<T> initial;
+        math::vec3<T> focus;
+        T delta_phi;
+        T delta_theta;
+        cam::scamera<T> expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/aabb.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/aabb.hpp
@@ -12,7 +12,7 @@ namespace stf::geom::scaffolding::aabb
     template<typename T, typename U, size_t N>
     struct cast
     {
-        geom::aabb<T, N> const initial;
+        geom::aabb<T, N> initial;
     };
 
     template<typename T, typename U, size_t N>
@@ -26,8 +26,8 @@ namespace stf::geom::scaffolding::aabb
     template<typename T, size_t N>
     struct intersects
     {
-        geom::aabb<T, N> const lhs;
-        geom::aabb<T, N> const rhs;
+        geom::aabb<T, N> lhs;
+        geom::aabb<T, N> rhs;
         bool intersect;
     };
 
@@ -44,8 +44,8 @@ namespace stf::geom::scaffolding::aabb
     template<typename T, size_t N>
     struct contains
     {
-        geom::aabb<T, N> const lhs;
-        geom::aabb<T, N> const rhs;
+        geom::aabb<T, N> lhs;
+        geom::aabb<T, N> rhs;
         bool contained;
     };
 
@@ -59,8 +59,8 @@ namespace stf::geom::scaffolding::aabb
     template<typename T, size_t N>
     struct dist_and_dist_squared
     {
-        geom::aabb<T, N> const box;
-        math::vec<T, N> const point;
+        geom::aabb<T, N> box;
+        math::vec<T, N> point;
         T dist_squared;
     };
 

--- a/code/tests/stf/include/private/stf/geom/scaffolding/obb.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/obb.hpp
@@ -12,7 +12,7 @@ namespace stf::geom::scaffolding::obb
     template<typename T, size_t N>
     struct from_aabb
     {
-        geom::aabb<T, N> const aabb;
+        geom::aabb<T, N> aabb;
     };
 
     template<typename T, size_t N>
@@ -29,9 +29,9 @@ namespace stf::geom::scaffolding::obb
     template<typename T, size_t N>
     struct extremity
     {
-        geom::obb<T, N> const obb;
-        math::vec<T, N> const axis;
-        math::vec<T, N> const extreme;
+        geom::obb<T, N> obb;
+        math::vec<T, N> axis;
+        math::vec<T, N> extreme;
     };
 
     template<typename T, size_t N>
@@ -43,9 +43,9 @@ namespace stf::geom::scaffolding::obb
     template<typename T, size_t N>
     struct contains
     {
-        geom::obb<T, N> const obb;
-        math::vec<T, N> const point;
-        bool const contains;
+        geom::obb<T, N> obb;
+        math::vec<T, N> point;
+        bool contains;
     };
 
     template<typename T, size_t N>
@@ -57,8 +57,8 @@ namespace stf::geom::scaffolding::obb
     template<typename T, size_t N>
     struct fit
     {
-        math::mtx<T, N> const rotation;
-        T const half_extent;
+        math::mtx<T, N> rotation;
+        T half_extent;
     };
 
     template<typename T, size_t N>
@@ -82,8 +82,8 @@ namespace stf::geom::scaffolding::obb
     template<typename T, size_t N>
     struct intersect
     {
-        geom::obb<T, N> const lhs;
-        geom::obb<T, N> const rhs;
+        geom::obb<T, N> lhs;
+        geom::obb<T, N> rhs;
         bool intersect;
     };
 

--- a/code/tests/stf/include/private/stf/geom/scaffolding/polygon.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/polygon.hpp
@@ -10,8 +10,8 @@ namespace stf::geom::scaffolding::polygon
     template<typename T>
     struct is_convex
     {
-        geom::polygon<T> const polygon;
-        bool const convex;
+        geom::polygon<T> polygon;
+        bool convex;
     };
 
     template<typename T>
@@ -23,8 +23,8 @@ namespace stf::geom::scaffolding::polygon
     template<typename T>
     struct signed_area
     {
-        geom::polygon<T> const polygon;
-        T const area;
+        geom::polygon<T> polygon;
+        T area;
     };
 
     template<typename T>
@@ -37,10 +37,10 @@ namespace stf::geom::scaffolding::polygon
     template<typename T>
     struct contains
     {
-        geom::polygon<T> const polygon;
-        math::vec2<T> const query;
-        boundary_types const boundary_type;
-        bool const contained;
+        geom::polygon<T> polygon;
+        math::vec2<T> query;
+        boundary_types boundary_type;
+        bool contained;
     };
 
     template<typename T>
@@ -52,8 +52,8 @@ namespace stf::geom::scaffolding::polygon
     template<typename T>
     struct distances
     {
-        geom::polygon<T> const polygon;
-        math::vec2<T> const query;
+        geom::polygon<T> polygon;
+        math::vec2<T> query;
         T signed_distance;
     };
 

--- a/code/tests/stf/include/private/stf/geom/scaffolding/polygon.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/polygon.hpp
@@ -54,7 +54,7 @@ namespace stf::geom::scaffolding::polygon
     {
         geom::polygon<T> const polygon;
         math::vec2<T> const query;
-        T const signed_distance;
+        T signed_distance;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/polyline.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/polyline.hpp
@@ -10,8 +10,8 @@ namespace stf::geom::scaffolding::polyline
     template<typename T, size_t N>
     struct length
     {
-        geom::polyline<T, N> const polyline;
-        T const len;
+        geom::polyline<T, N> polyline;
+        T len;
     };
 
     template<typename T, size_t N>
@@ -23,8 +23,8 @@ namespace stf::geom::scaffolding::polyline
     template<typename T, size_t N>
     struct dist_and_dist_squared
     {
-        geom::polyline<T, N> const polyline;
-        math::vec<T, N> const point;
+        geom::polyline<T, N> polyline;
+        math::vec<T, N> point;
         T dist_squared;
     };
 
@@ -43,9 +43,9 @@ namespace stf::geom::scaffolding::polyline
     template<typename T, size_t N>
     struct interpolate
     {
-        geom::polyline<T, N> const polyline;
-        T const t;
-        math::vec<T, N> const point;
+        geom::polyline<T, N> polyline;
+        T t;
+        math::vec<T, N> point;
     };
 
     template<typename T, size_t N>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/polyline.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/polyline.hpp
@@ -25,7 +25,7 @@ namespace stf::geom::scaffolding::polyline
     {
         geom::polyline<T, N> const polyline;
         math::vec<T, N> const point;
-        T const dist_squared;
+        T dist_squared;
     };
 
     template<typename T, size_t N>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/ray.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/ray.hpp
@@ -11,8 +11,8 @@ namespace stf::geom::scaffolding::ray
     template<typename T, size_t N>
     struct dist_and_dist_squared
     {
-        geom::ray<T, N> const beam;
-        math::vec<T, N> const point;
+        geom::ray<T, N> beam;
+        math::vec<T, N> point;
         T dist_squared;
     };
 

--- a/code/tests/stf/include/private/stf/geom/scaffolding/ray.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/ray.hpp
@@ -13,7 +13,7 @@ namespace stf::geom::scaffolding::ray
     {
         geom::ray<T, N> const beam;
         math::vec<T, N> const point;
-        T const dist_squared;
+        T dist_squared;
     };
 
     template<typename T, size_t N>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/segment.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/segment.hpp
@@ -10,8 +10,8 @@ namespace stf::geom::scaffolding::segment
     template<typename T, size_t N>
     struct dist_and_dist_squared
     {
-        geom::segment<T, N> const seg;
-        math::vec<T, N> const point;
+        geom::segment<T, N> seg;
+        math::vec<T, N> point;
         T dist_squared;
     };
 
@@ -29,9 +29,9 @@ namespace stf::geom::scaffolding::segment
     template<typename T, size_t N>
     struct interpolate
     {
-        geom::segment<T, N> const seg;
-        T const t;
-        math::vec<T, N> const point;
+        geom::segment<T, N> seg;
+        T t;
+        math::vec<T, N> point;
     };
 
     template<typename T, size_t N>

--- a/code/tests/stf/include/private/stf/geom/scaffolding/segment.hpp
+++ b/code/tests/stf/include/private/stf/geom/scaffolding/segment.hpp
@@ -12,7 +12,7 @@ namespace stf::geom::scaffolding::segment
     {
         geom::segment<T, N> const seg;
         math::vec<T, N> const point;
-        T const dist_squared;
+        T dist_squared;
     };
 
     template<typename T, size_t N>

--- a/code/tests/stf/include/private/stf/gfx/scaffolding/color.hpp
+++ b/code/tests/stf/include/private/stf/gfx/scaffolding/color.hpp
@@ -9,8 +9,8 @@ namespace stf::gfx::scaffolding::color
 
     struct rgba_equality
     {
-        rgba const lhs;
-        rgba const rhs;
+        rgba lhs;
+        rgba rhs;
         bool equal;
     };
 
@@ -34,10 +34,10 @@ namespace stf::gfx::scaffolding::color
 
     struct rgba_hex_conversion
     {
-        uint32_t const hex_rgba;
-        uint32_t const hex_abgr;
-        uint32_t const hex_argb;
-        rgba const color;
+        uint32_t hex_rgba;
+        uint32_t hex_abgr;
+        uint32_t hex_argb;
+        rgba color;
     };
 
     void verify(rgba_hex_conversion const& test)

--- a/code/tests/stf/include/private/stf/math/scaffolding/cinterval.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/cinterval.hpp
@@ -10,9 +10,9 @@ namespace stf::math::scaffolding::cinterval
     template<typename T>
     struct contains_point
     {
-        math::cinterval<T> const interval;
-        boundary_types const type;
-        T const x;
+        math::cinterval<T> interval;
+        boundary_types type;
+        T x;
         bool contained;
     };
 

--- a/code/tests/stf/include/private/stf/math/scaffolding/interpolation.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/interpolation.hpp
@@ -11,10 +11,10 @@ namespace stf::math::scaffolding::interpolation
     template<typename T>
     struct lerp
     {
-        T const a;
-        T const b;
-        T const t;
-        T const expected;
+        T a;
+        T b;
+        T t;
+        T expected;
     };
 
     template<typename T>
@@ -26,10 +26,10 @@ namespace stf::math::scaffolding::interpolation
     template<typename T>
     struct lerp_inv
     {
-        T const a;
-        T const b;
-        T const x;
-        T const expected;
+        T a;
+        T b;
+        T x;
+        T expected;
     };
 
     template<typename T>
@@ -41,10 +41,10 @@ namespace stf::math::scaffolding::interpolation
     template<typename T>
     struct lerpstep
     {
-        T const a;
-        T const b;
-        T const t;
-        T const expected;
+        T a;
+        T b;
+        T t;
+        T expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/math/scaffolding/interval.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/interval.hpp
@@ -10,9 +10,9 @@ namespace stf::math::scaffolding::interval
     template<typename T>
     struct contains_point
     {
-        math::interval<T> const interval;
-        boundary_types const type;
-        T const x;
+        math::interval<T> interval;
+        boundary_types type;
+        T x;
         bool contained;
     };
 

--- a/code/tests/stf/include/private/stf/math/scaffolding/spherical.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/spherical.hpp
@@ -11,8 +11,8 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct conversion
     {
-        T const radians;
-        T const degrees;
+        T radians;
+        T degrees;
     };
 
     template<typename T>
@@ -25,8 +25,8 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct canonical_angle
     {
-        T const radians;
-        T const expected;
+        T radians;
+        T expected;
     };
 
     template<typename T>
@@ -38,9 +38,9 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct closest_equiv_angle
     {
-        T const phi;
-        T const theta;
-        T const expected;
+        T phi;
+        T theta;
+        T expected;
     };
 
     template<typename T>
@@ -53,9 +53,9 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct counterclockwise_angle
     {
-        vec2<T> const u;
-        vec2<T> const v;
-        T const theta;
+        vec2<T> u;
+        vec2<T> v;
+        T theta;
     };
 
     template<typename T>
@@ -67,8 +67,8 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct unit_vec2
     {
-        T const theta;
-        math::vec<T, 2> const expected;
+        T theta;
+        math::vec<T, 2> expected;
     };
 
     template<typename T>
@@ -80,10 +80,10 @@ namespace stf::math::scaffolding::spherical
     template<typename T>
     struct to_euclidean
     {
-        T const radius;
-        T const theta;
-        T const phi;
-        math::vec<T, 3> const expected;
+        T radius;
+        T theta;
+        T phi;
+        math::vec<T, 3> expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/math/scaffolding/transform.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/transform.hpp
@@ -11,9 +11,9 @@ namespace stf::math::scaffolding::transform
     template<typename T>
     struct rotate2
     {
-        math::vec<T, 2> const initial;
-        T const delta_theta;
-        math::vec<T, 2> const expected;
+        math::vec<T, 2> initial;
+        T delta_theta;
+        math::vec<T, 2> expected;
     };
 
     template<typename T>
@@ -26,10 +26,10 @@ namespace stf::math::scaffolding::transform
     template<typename T>
     struct orbit2
     {
-        math::vec<T, 2> const initial;
-        math::vec<T, 2> const focus;
-        T const delta_theta;
-        math::vec<T, 2> const expected;
+        math::vec<T, 2> initial;
+        math::vec<T, 2> focus;
+        T delta_theta;
+        math::vec<T, 2> expected;
     };
 
     template<typename T>
@@ -41,10 +41,10 @@ namespace stf::math::scaffolding::transform
     template<typename T>
     struct rotate3
     {
-        math::vec<T, 3> const initial;
-        math::vec<T, 3> const axis;
-        T const delta_theta;
-        math::vec<T, 3> const expected;
+        math::vec<T, 3> initial;
+        math::vec<T, 3> axis;
+        T delta_theta;
+        math::vec<T, 3> expected;
     };
 
     template<typename T>
@@ -58,12 +58,12 @@ namespace stf::math::scaffolding::transform
     template<typename T>
     struct orbit3
     {
-        math::vec<T, 3> const initial;
-        math::vec<T, 3> const focus;
-        math::vec<T, 3> const right;
-        T const delta_phi;
-        T const delta_theta;
-        math::vec<T, 3> const expected;
+        math::vec<T, 3> initial;
+        math::vec<T, 3> focus;
+        math::vec<T, 3> right;
+        T delta_phi;
+        T delta_theta;
+        math::vec<T, 3> expected;
     };
 
     template<typename T>

--- a/code/tests/stf/include/private/stf/math/scaffolding/vector.hpp
+++ b/code/tests/stf/include/private/stf/math/scaffolding/vector.hpp
@@ -10,8 +10,8 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct equality
     {
-        math::vec<T, N> const lhs;
-        math::vec<T, N> const rhs;
+        math::vec<T, N> lhs;
+        math::vec<T, N> rhs;
         bool equal;
     };
 
@@ -37,8 +37,8 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct read
     {
-        math::vec<T, N> const lhs;
-        T const expected[N];
+        math::vec<T, N> lhs;
+        T expected[N];
     };
 
     template<typename T, size_t N>
@@ -83,9 +83,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct write
     {
-        math::vec<T, N> const initial;
-        size_t const index;
-        T const value;
+        math::vec<T, N> initial;
+        size_t index;
+        T value;
     };
 
     template<typename T, size_t N>
@@ -99,9 +99,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct add
     {
-        math::vec<T, N> const lhs;
-        math::vec<T, N> const rhs;
-        math::vec<T, N> const expected;
+        math::vec<T, N> lhs;
+        math::vec<T, N> rhs;
+        math::vec<T, N> expected;
     };
 
     template<typename T, size_t N>
@@ -117,9 +117,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct subtract
     {
-        math::vec<T, N> const lhs;
-        math::vec<T, N> const rhs;
-        math::vec<T, N> const expected;
+        math::vec<T, N> lhs;
+        math::vec<T, N> rhs;
+        math::vec<T, N> expected;
     };
 
     template<typename T, size_t N>
@@ -135,9 +135,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct scale
     {
-        math::vec<T, N> const initial;
-        T const scalar;
-        math::vec<T, N> const expected;
+        math::vec<T, N> initial;
+        T scalar;
+        math::vec<T, N> expected;
     };
 
     template<typename T, size_t N>
@@ -152,9 +152,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct dot
     {
-        math::vec<T, N> const lhs;
-        math::vec<T, N> const rhs;
-        T const expected;
+        math::vec<T, N> lhs;
+        math::vec<T, N> rhs;
+        T expected;
     };
 
     template<typename T, size_t N>
@@ -169,8 +169,8 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct length
     {
-        math::vec<T, N> const initial;
-        T const expected;
+        math::vec<T, N> initial;
+        T expected;
     };
 
     template<typename T, size_t N>
@@ -182,8 +182,8 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct normalize
     {
-        math::vec<T, N> const initial;
-        math::vec<T, N> const expected;
+        math::vec<T, N> initial;
+        math::vec<T, N> expected;
     };
 
     template<typename T, size_t N>
@@ -197,7 +197,7 @@ namespace stf::math::scaffolding::vec
     template<typename T, typename U, size_t N>
     struct cast
     {
-        math::vec<T, N> const initial;
+        math::vec<T, N> initial;
     };
 
     template<typename T, typename U, size_t N>
@@ -213,7 +213,7 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct negate
     {
-        math::vec<T, N> const initial;
+        math::vec<T, N> initial;
     };
 
     template<typename T, size_t N>
@@ -229,9 +229,9 @@ namespace stf::math::scaffolding::vec
     template<typename T, size_t N>
     struct binary_op
     {
-        math::vec<T, N> const lhs;
-        math::vec<T, N> const rhs;
-        math::vec<T, N> const expected;
+        math::vec<T, N> lhs;
+        math::vec<T, N> rhs;
+        math::vec<T, N> expected;
     };
 
 } // stf::math::scaffolding::vec


### PR DESCRIPTION
## Summary

The primary purpose of this PR is to fix a const-correctness leak in the `row_proxy`/`col_proxy` structs that `mtx` provides.

This PR introduces `const_row_proxy`/`const_col_proxy` so that const-correctness can be preserved. A `row_proxy const` can be copied to a `row_proxy` and then the underlying `mtx` can be changed. This continues to be the case. However, `mtx const` now returns a `const_row_proxy` from `operator[]` and `const_row_proxy` _cannot_ be copied to a `row_proxy` (though, similar to iterators from the STL, `row_proxy` can be copied to `const_row_proxy`).

I also removed a bunch of `const` on return types because I learned that prevents moving of returned objects.