### PR TITLE
Include googletest in attribution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,5 +23,6 @@ Any uninstantiated code is necessarily uncovered so the coverage is over-estimat
 Many thanks to the open-source software that enables this project.
 
 * [cmake](https://cmake.org/)
+* [googletest](https://github.com/google/googletest.git)
 * [doxygen](https://www.doxygen.nl/)
 * [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css)


### PR DESCRIPTION
## Summary

Include [googletest](https://github.com/google/googletest.git) in attribution