### PR TITLE
Explicit OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: print compilers
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: ls $(where g++)
+        run: ls $(whereis g++)
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,21 @@ jobs:
           #   cpp_compiler: clang++-18
           #   c_compiler: clang-18
           #   generator: Unix Makefiles
+          - os: ubuntu-24.04
+            cpp_compiler: [clang++-16, clang++-17, clang++-18]
+            generator: Unix Makefiles
+        include:
+          - cpp_compiler: clang++-16
+            c_compiler: clang-16
+          - cpp_compiler: clang++-17
+            c_compiler: clang-17
+          - cpp_compiler: clang++-18
+            c_compiler: clang-18
           # windows-2022 hosts
-          - os: windows-2022
-            cpp_compiler: cl
-            c_compiler: cl
-            generator: Visual Studio 17 2022
+          # - os: windows-2022
+          #   cpp_compiler: cl
+          #   c_compiler: cl
+          #   generator: Visual Studio 17 2022
           # macos-14 hosts
       # Set up a matrix to run the different configurations:
       # matrix:
@@ -82,8 +92,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      - name: Setup ssh session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup ssh session
+      #   uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,46 +67,6 @@ jobs:
                 c_compiler: clang
                 os: ubuntu-24.04
                 generator: Unix Makefiles
-      # Set up a matrix to run the different configurations:
-      # matrix:
-      #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
-      #   cpp_compiler: [cl, g++, clang++]
-      #   os: [windows-2022, ubuntu-24.04, macos-14]
-      #   exclude:
-      #     # exclude incompatible operating systems and compilers
-      #     - os: windows-2022
-      #       cpp_compiler: clang++
-      #     - os: ubuntu-24.04
-      #       cpp_compiler: cl
-      #     - os: macos-14
-      #       cpp_compiler: cl
-      #     - os: macos-14
-      #       cpp_compiler: g++
-      #   include:
-      #     # for a particular cpp compiler, specify the c compiler
-      #     - cpp_compiler: cl
-      #       c_compiler: cl
-      #     - cpp_compiler: g++
-      #       c_compiler: gcc
-      #     - cpp_compiler: clang++
-      #       c_compiler: clang
-      #     # for a particular operating system and compiler, specify the generator
-      #     - os: windows-2022
-      #       cpp_compiler: cl
-      #       generator: Visual Studio 17 2022
-      #     - os: windows-2022
-      #       cpp_compiler: g++
-      #       generator: MinGW Makefiles
-      #     - os: ubuntu-24.04
-      #       generator: Unix Makefiles
-      #     - os: macos-14
-      #       generator: Unix Makefiles
-      #     # add the coverage build type
-      #     - build_type: Coverage
-      #       cpp_compiler: clang++
-      #       c_compiler: clang
-      #       os: ubuntu-24.04
-      #       generator: Unix Makefiles
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,8 +78,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      - name: Setup ssh session
-        uses: lhotari/action-upterm@v1
+      # - name: Setup ssh session
+      #   uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         host:
           # cl configurations
           - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2022 }
+          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2019 }
           # clang++ configurations
           - { cpp_compiler: clang++-16, c_compiler: clang-16, image: ubuntu-24.04, generator: Unix Makefiles        }
           - { cpp_compiler: clang++-17, c_compiler: clang-17, image: ubuntu-24.04, generator: Unix Makefiles        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         host:
           # cl configurations
           - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2022 }
-          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2019 }
+          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 16 2019 }
           # clang++ configurations
           - { cpp_compiler: clang++-16, c_compiler: clang-16, image: ubuntu-24.04, generator: Unix Makefiles        }
           - { cpp_compiler: clang++-17, c_compiler: clang-17, image: ubuntu-24.04, generator: Unix Makefiles        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,26 @@ jobs:
             os: macos-14
             generator: Unix Makefiles
           # g++ configurations
+          - cpp_compiler: g++-12
+            c_compiler: gcc-12
+            os: windows-2022
+            generator: MinGW Makefiles
+          - cpp_compiler: g++-12
+            c_compiler: gcc-12
+            os: ubuntu-24.04
+            generator: Unix Makefiles
+          - cpp_compiler: g++-13
+            c_compiler: gcc-13
+            os: ubuntu-24.04
+            generator: Unix Makefiles
+          - cpp_compiler: g++-14
+            c_compiler: gcc-14
+            os: ubuntu-24.04
+            generator: Unix Makefiles
+          - cpp_compiler: g++
+            c_compiler: gcc
+            os: macos-14
+            generator: Unix Makefiles
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
         # macos-14:     https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         host:
           # cl configurations
+          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2019, generator: Visual Studio 16 2019 }
           - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2022 }
-          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 16 2019 }
           # clang++ configurations
           - { cpp_compiler: clang++-16, c_compiler: clang-16, image: ubuntu-24.04, generator: Unix Makefiles        }
           - { cpp_compiler: clang++-17, c_compiler: clang-17, image: ubuntu-24.04, generator: Unix Makefiles        }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,13 @@ jobs:
             c_compiler: gcc
             os: macos-14
             generator: Unix Makefiles
+        include:
+          - build_type: Coverage
+            host:
+              - cpp_compiler: clang++
+                c_compiler: clang
+                os: ubuntu-24.04
+                generator: Unix Makefiles
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
-          - os: ubuntu-24.04
+          - os: macos-14
             cpp_compiler: g++
             c_compiler: gcc
             generator: Unix Makefiles

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,36 +19,23 @@ jobs:
         host:
           # cl configurations
           # - cpp_compiler: cl
+          #   c_compiler: cl
           #   os: windows-2022
           #   generator: Visual Studio 17 2022
           # clang++ configurations
           - cpp_compiler: clang++-16
+            c_compiler: clang-16
             os: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-17
+            c_compiler: clang-17
             os: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-18
+            c_compiler: clang-18
             os: ubuntu-24.04
             generator: Unix Makefiles
           # g++ configurations
-        include:
-          # for a particular cpp compiler, specify the c compiler
-          # - host:
-          #   - cpp_compiler: cl
-          #     c_compiler: cl
-          - host:
-            - cpp_compiler: clang++-16
-              c_compiler: clang-16
-          - host:
-            - cpp_compiler: clang++-17
-              c_compiler: clang-17
-          - host:
-            - cpp_compiler: clang++-18
-              c_compiler: clang-18
-          # - host:
-          #   - cpp_compiler: g++-12
-          #     c_compiler: gcc-12
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,13 @@ jobs:
       # Cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
       fail-fast: true
 
-      # image states
-      # windows-2022: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
-      # ubuntu-24.04: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-      # macos-14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+      # matrix docs: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
+        # image states
+        # windows-2022: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+        # ubuntu-24.04: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+        # macos-14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         host:
           # cl configurations
           - cpp_compiler: cl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,11 +49,11 @@ jobs:
           - os: macos-14
             generator: Unix Makefiles
           # add the coverage build type
-          - build_type: Coverage
-            cpp_compiler: clang++
-            c_compiler: clang
-            os: ubuntu-24.04
-            generator: Unix Makefiles
+          # - build_type: Coverage
+          #   cpp_compiler: clang++
+          #   c_compiler: clang
+          #   os: ubuntu-24.04
+          #   generator: Unix Makefiles
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       # Cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
-      fail-fast: true
+      fail-fast: false
 
       # Set up a matrix to run the different configurations:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,23 @@ jobs:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
           # ubuntu-24.04 hosts
-          - os: ubuntu-24.04
-            cpp_compiler: clang++-16
-            c_compiler: clang-16
-            generator: Unix Makefiles
-          - os: ubuntu-24.04
-            cpp_compiler: clang++-17
-            c_compiler: clang-17
-            generator: Unix Makefiles
-          - os: ubuntu-24.04
-            cpp_compiler: clang++-18
-            c_compiler: clang-18
-            generator: Unix Makefiles
+          # - os: ubuntu-24.04
+          #   cpp_compiler: clang++-16
+          #   c_compiler: clang-16
+          #   generator: Unix Makefiles
+          # - os: ubuntu-24.04
+          #   cpp_compiler: clang++-17
+          #   c_compiler: clang-17
+          #   generator: Unix Makefiles
+          # - os: ubuntu-24.04
+          #   cpp_compiler: clang++-18
+          #   c_compiler: clang-18
+          #   generator: Unix Makefiles
           # windows-2022 hosts
+          - os: windows-2022
+            cpp_compiler: cl
+            c_compiler: cl
+            generator: Visual Studio 17 2022
           # macos-14 hosts
       # Set up a matrix to run the different configurations:
       # matrix:
@@ -78,8 +82,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      # - name: Setup ssh session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup ssh session
+        uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
           # cl configurations
-          # - cpp_compiler: cl
-          #   c_compiler: cl
-          #   os: windows-2022
-          #   generator: Visual Studio 17 2022
+          - cpp_compiler: cl
+            c_compiler: cl
+            os: windows-2022
+            generator: Visual Studio 17 2022
           # clang++ configurations
           - cpp_compiler: clang++-16
             c_compiler: clang-16
@@ -34,6 +34,10 @@ jobs:
           - cpp_compiler: clang++-18
             c_compiler: clang-18
             os: ubuntu-24.04
+            generator: Unix Makefiles
+          - cpp_compiler: clang++
+            c_compiler: clang
+            os: macos-14
             generator: Unix Makefiles
           # g++ configurations
       # Set up a matrix to run the different configurations:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,35 +17,34 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
-          # ubuntu-24.04 hosts
-          # - os: ubuntu-24.04
-          #   cpp_compiler: clang++-16
-          #   c_compiler: clang-16
-          #   generator: Unix Makefiles
-          # - os: ubuntu-24.04
-          #   cpp_compiler: clang++-17
-          #   c_compiler: clang-17
-          #   generator: Unix Makefiles
-          # - os: ubuntu-24.04
-          #   cpp_compiler: clang++-18
-          #   c_compiler: clang-18
-          #   generator: Unix Makefiles
-          - os: ubuntu-24.04
-            cpp_compiler: [clang++-16, clang++-17, clang++-18]
-            generator: Unix Makefiles
-        include:
+          # clang configurations
           - cpp_compiler: clang++-16
-            c_compiler: clang-16
+            os: ubuntu-24.04
+            generator: Unix Makefiles
           - cpp_compiler: clang++-17
-            c_compiler: clang-17
+            os: ubuntu-24.04
+            generator: Unix Makefiles
           - cpp_compiler: clang++-18
-            c_compiler: clang-18
+            os: ubuntu-24.04
+            generator: Unix Makefiles
           # windows-2022 hosts
           # - os: windows-2022
           #   cpp_compiler: cl
           #   c_compiler: cl
           #   generator: Visual Studio 17 2022
           # macos-14 hosts
+        include:
+          # for a particular cpp compiler, specify the c compiler
+          # - cpp_compiler: cl
+          #   c_compiler: cl
+          - cpp_compiler: clang++-16
+            c_compiler: clang-16
+          - cpp_compiler: clang++-17
+            c_compiler: clang-17
+          - cpp_compiler: clang++-18
+            c_compiler: clang-18
+          # - cpp_compiler: g++-12
+          #   c_compiler: gcc-12
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,8 @@ jobs:
         uses: actions/checkout@v3
 
       # Use this to set up an open ssh debugging session with CI
-      # - name: Setup ssh session
-      #   uses: lhotari/action-upterm@v1
+      - name: Setup ssh session
+        uses: lhotari/action-upterm@v1
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -78,11 +78,6 @@ jobs:
           echo "src-dir=${{ github.workspace }}/code/src" >> "$GITHUB_OUTPUT"
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
           echo "tests-output-dir=${{ github.workspace }}/build/code/tests/stf" >> "$GITHUB_OUTPUT"
-
-      - name: print compilers
-        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: ls $(whereis g++)
 
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,9 @@ jobs:
           - { cpp_compiler: g++-13,     c_compiler: gcc-13,   image: ubuntu-24.04, generator: Unix Makefiles        }
           - { cpp_compiler: g++-14,     c_compiler: gcc-14,   image: ubuntu-24.04, generator: Unix Makefiles        }
           - { cpp_compiler: g++,        c_compiler: gcc,      image: macos-14,     generator: Unix Makefiles        }
-        # include:
-        #   - build_type: Coverage
-        #     host:
-        #       - cpp_compiler: clang++
-        #         c_compiler: clang
-        #         image: ubuntu-24.04
-        #         generator: Unix Makefiles
+        include:
+          - build_type: Coverage
+            host: { cpp_compiler: clang++, c_compiler: clang, image: ubuntu-24.04, generator: Unix Makefiles        }
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         cpp_compiler: [cl, g++, clang++]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2022, ubuntu-24.04, macos-14]
         exclude:
           # exclude incompatible operating systems and compilers
-          - os: windows-latest
+          - os: windows-2022
             cpp_compiler: clang++
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             cpp_compiler: cl
-          - os: macos-latest
+          - os: macos-14
             cpp_compiler: cl
-          - os: macos-latest
+          - os: macos-14
             cpp_compiler: g++
         include:
           # for a particular cpp compiler, specify the c compiler
@@ -38,21 +38,21 @@ jobs:
           - cpp_compiler: clang++
             c_compiler: clang
           # for a particular operating system and compiler, specify the generator
-          - os: windows-latest
+          - os: windows-2022
             cpp_compiler: cl
             generator: Visual Studio 17 2022
-          - os: windows-latest
+          - os: windows-2022
             cpp_compiler: g++
             generator: MinGW Makefiles
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             generator: Unix Makefiles
-          - os: macos-latest
+          - os: macos-14
             generator: Unix Makefiles
           # add the coverage build type
           - build_type: Coverage
             cpp_compiler: clang++
             c_compiler: clang
-            os: ubuntu-latest
+            os: ubuntu-24.04
             generator: Unix Makefiles
 
     steps:
@@ -120,7 +120,7 @@ jobs:
           fail_ci_if_error: true
 
   docs:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
           fail_ci_if_error: true
 
   docs:
-    runs-on: "ubuntu-24.04"
+    runs-on: ubuntu-24.04
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         # image states
         # windows-2022: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         # ubuntu-24.04: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-        # macos-14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+        # macos-14:     https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         host:
           # cl configurations
           - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2022 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       # Cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
-      fail-fast: false
+      fail-fast: true
 
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,52 +8,62 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.host.os }}
 
     strategy:
       # Cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
       fail-fast: false
 
-      # Set up a matrix to run the different configurations:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
-        cpp_compiler: [cl, g++, clang++]
-        os: [windows-2022, ubuntu-24.04, macos-14]
-        exclude:
-          # exclude incompatible operating systems and compilers
-          - os: windows-2022
-            cpp_compiler: clang++
+        host:
           - os: ubuntu-24.04
-            cpp_compiler: cl
-          - os: macos-14
-            cpp_compiler: cl
-          - os: macos-14
-            cpp_compiler: g++
-        include:
-          # for a particular cpp compiler, specify the c compiler
-          - cpp_compiler: cl
-            c_compiler: cl
-          - cpp_compiler: g++
-            c_compiler: gcc
-          - cpp_compiler: clang++
-            c_compiler: clang
-          # for a particular operating system and compiler, specify the generator
-          - os: windows-2022
-            cpp_compiler: cl
-            generator: Visual Studio 17 2022
-          - os: windows-2022
-            cpp_compiler: g++
-            generator: MinGW Makefiles
-          - os: ubuntu-24.04
+            compiler:
+              - cpp: g++
+                c: gcc
+              - cpp: clang++
+                c: clang
             generator: Unix Makefiles
-          - os: macos-14
-            generator: Unix Makefiles
-          # add the coverage build type
-          # - build_type: Coverage
-          #   cpp_compiler: clang++
-          #   c_compiler: clang
-          #   os: ubuntu-24.04
-          #   generator: Unix Makefiles
+      # Set up a matrix to run the different configurations:
+      # matrix:
+      #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
+      #   cpp_compiler: [cl, g++, clang++]
+      #   os: [windows-2022, ubuntu-24.04, macos-14]
+      #   exclude:
+      #     # exclude incompatible operating systems and compilers
+      #     - os: windows-2022
+      #       cpp_compiler: clang++
+      #     - os: ubuntu-24.04
+      #       cpp_compiler: cl
+      #     - os: macos-14
+      #       cpp_compiler: cl
+      #     - os: macos-14
+      #       cpp_compiler: g++
+      #   include:
+      #     # for a particular cpp compiler, specify the c compiler
+      #     - cpp_compiler: cl
+      #       c_compiler: cl
+      #     - cpp_compiler: g++
+      #       c_compiler: gcc
+      #     - cpp_compiler: clang++
+      #       c_compiler: clang
+      #     # for a particular operating system and compiler, specify the generator
+      #     - os: windows-2022
+      #       cpp_compiler: cl
+      #       generator: Visual Studio 17 2022
+      #     - os: windows-2022
+      #       cpp_compiler: g++
+      #       generator: MinGW Makefiles
+      #     - os: ubuntu-24.04
+      #       generator: Unix Makefiles
+      #     - os: macos-14
+      #       generator: Unix Makefiles
+      #     # add the coverage build type
+      #     - build_type: Coverage
+      #       cpp_compiler: clang++
+      #       c_compiler: clang
+      #       os: ubuntu-24.04
+      #       generator: Unix Makefiles
 
     steps:
       - name: checkout
@@ -77,10 +87,10 @@ jobs:
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: >
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-          -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.host.compiler.cpp }}
+          -DCMAKE_C_COMPILER=${{ matrix.host.compiler.c }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -G "${{ matrix.generator }}"
+          -G "${{ matrix.host.generator }}"
           -S ${{ github.workspace }}
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,8 @@ jobs:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
           - os: ubuntu-24.04
-            compiler:
-              - cpp: g++
-                c: gcc
-              - cpp: clang++
-                c: clang
+            cpp_compiler: g++
+            c_compiler: g
             generator: Unix Makefiles
       # Set up a matrix to run the different configurations:
       # matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,13 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
-          # clang configurations
+          # cl configurations
+          # - cpp_compiler: cl
+          #   os: windows-2022
+          #   generator: Visual Studio 17 2022
+          # clang++ configurations
           - cpp_compiler: clang++-16
+          - c_compiler: clang-16
             os: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-17
@@ -27,12 +32,7 @@ jobs:
           - cpp_compiler: clang++-18
             os: ubuntu-24.04
             generator: Unix Makefiles
-          # windows-2022 hosts
-          # - os: windows-2022
-          #   cpp_compiler: cl
-          #   c_compiler: cl
-          #   generator: Visual Studio 17 2022
-          # macos-14 hosts
+          # g++ configurations
         include:
           # for a particular cpp compiler, specify the c compiler
           # - cpp_compiler: cl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           #   generator: Visual Studio 17 2022
           # clang++ configurations
           - cpp_compiler: clang++-16
-          - c_compiler: clang-16
+            c_compiler: clang-16
             os: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-17

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,8 @@ jobs:
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
         run: >
           cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          -DCMAKE_CXX_COMPILER=${{ matrix.host.compiler.cpp }}
-          -DCMAKE_C_COMPILER=${{ matrix.host.compiler.c }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.host.cpp_compiler }}
+          -DCMAKE_C_COMPILER=${{ matrix.host.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -G "${{ matrix.host.generator }}"
           -S ${{ github.workspace }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,13 @@ jobs:
             c_compiler: clang-18
             os: ubuntu-24.04
             generator: Unix Makefiles
-          - cpp_compiler: clang++
+          - cpp_compiler: clang++   # GHA docs say this is version 15.0.0 https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
             c_compiler: clang
             os: macos-14
             generator: Unix Makefiles
           # g++ configurations
-          - cpp_compiler: g++-12
-            c_compiler: gcc-12
+          - cpp_compiler: g++   # GHA docs say this is version 12.2.0 https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+            c_compiler: gcc
             os: windows-2022
             generator: MinGW Makefiles
           - cpp_compiler: g++-12

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,55 +23,25 @@ jobs:
         # macos-14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         host:
           # cl configurations
-          - cpp_compiler: cl
-            c_compiler: cl
-            image: windows-2022
-            generator: Visual Studio 17 2022
+          - { cpp_compiler: cl,         c_compiler: cl,       image: windows-2022, generator: Visual Studio 17 2022 }
           # clang++ configurations
-          - cpp_compiler: clang++-16
-            c_compiler: clang-16
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: clang++-17
-            c_compiler: clang-17
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: clang++-18
-            c_compiler: clang-18
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: clang++   # GHA docs say this is version 15.0.0 https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
-            c_compiler: clang
-            image: macos-14
-            generator: Unix Makefiles
+          - { cpp_compiler: clang++-16, c_compiler: clang-16, image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: clang++-17, c_compiler: clang-17, image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: clang++-18, c_compiler: clang-18, image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: clang++,    c_compiler: clang,    image: macos-14,     generator: Unix Makefiles        } # GHA docs say this is version 15.0.0
           # g++ configurations
-          - cpp_compiler: g++   # GHA docs say this is version 12.2.0 https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-            c_compiler: gcc
-            image: windows-2022
-            generator: MinGW Makefiles
-          - cpp_compiler: g++-12
-            c_compiler: gcc-12
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: g++-13
-            c_compiler: gcc-13
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: g++-14
-            c_compiler: gcc-14
-            image: ubuntu-24.04
-            generator: Unix Makefiles
-          - cpp_compiler: g++
-            c_compiler: gcc
-            image: macos-14
-            generator: Unix Makefiles
-        include:
-          - build_type: Coverage
-            host:
-              - cpp_compiler: clang++
-                c_compiler: clang
-                image: ubuntu-24.04
-                generator: Unix Makefiles
+          - { cpp_compiler: g++,        c_compiler: gcc,      image: windows-2022, generator: MinGW Makefiles       } # GHA docs say this is version 12.2.0
+          - { cpp_compiler: g++-12,     c_compiler: gcc-12,   image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: g++-13,     c_compiler: gcc-13,   image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: g++-14,     c_compiler: gcc-14,   image: ubuntu-24.04, generator: Unix Makefiles        }
+          - { cpp_compiler: g++,        c_compiler: gcc,      image: macos-14,     generator: Unix Makefiles        }
+        # include:
+        #   - build_type: Coverage
+        #     host:
+        #       - cpp_compiler: clang++
+        #         c_compiler: clang
+        #         image: ubuntu-24.04
+        #         generator: Unix Makefiles
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,11 @@ jobs:
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
           echo "tests-output-dir=${{ github.workspace }}/build/code/tests/stf" >> "$GITHUB_OUTPUT"
 
+      - name: print compilers
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: ls $(where g++)
+
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,64 +8,68 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.host.os }}
+    runs-on: ${{ matrix.host.image }}
 
     strategy:
       # Cancel all in-progress and queued jobs in the matrix if any job in the matrix fails
       fail-fast: true
 
+      # image states
+      # windows-2022: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
+      # ubuntu-24.04: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+      # macos-14: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
           # cl configurations
           - cpp_compiler: cl
             c_compiler: cl
-            os: windows-2022
+            image: windows-2022
             generator: Visual Studio 17 2022
           # clang++ configurations
           - cpp_compiler: clang++-16
             c_compiler: clang-16
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-17
             c_compiler: clang-17
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-18
             c_compiler: clang-18
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++   # GHA docs say this is version 15.0.0 https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
             c_compiler: clang
-            os: macos-14
+            image: macos-14
             generator: Unix Makefiles
           # g++ configurations
           - cpp_compiler: g++   # GHA docs say this is version 12.2.0 https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
             c_compiler: gcc
-            os: windows-2022
+            image: windows-2022
             generator: MinGW Makefiles
           - cpp_compiler: g++-12
             c_compiler: gcc-12
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: g++-13
             c_compiler: gcc-13
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: g++-14
             c_compiler: gcc-14
-            os: ubuntu-24.04
+            image: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: g++
             c_compiler: gcc
-            os: macos-14
+            image: macos-14
             generator: Unix Makefiles
         include:
           - build_type: Coverage
             host:
               - cpp_compiler: clang++
                 c_compiler: clang
-                os: ubuntu-24.04
+                image: ubuntu-24.04
                 generator: Unix Makefiles
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
           #   generator: Visual Studio 17 2022
           # clang++ configurations
           - cpp_compiler: clang++-16
-            c_compiler: clang-16
             os: ubuntu-24.04
             generator: Unix Makefiles
           - cpp_compiler: clang++-17
@@ -35,16 +34,21 @@ jobs:
           # g++ configurations
         include:
           # for a particular cpp compiler, specify the c compiler
-          # - cpp_compiler: cl
-          #   c_compiler: cl
-          - cpp_compiler: clang++-16
-            c_compiler: clang-16
-          - cpp_compiler: clang++-17
-            c_compiler: clang-17
-          - cpp_compiler: clang++-18
-            c_compiler: clang-18
-          # - cpp_compiler: g++-12
-          #   c_compiler: gcc-12
+          # - host:
+          #   - cpp_compiler: cl
+          #     c_compiler: cl
+          - host:
+            - cpp_compiler: clang++-16
+              c_compiler: clang-16
+          - host:
+            - cpp_compiler: clang++-17
+              c_compiler: clang-17
+          - host:
+            - cpp_compiler: clang++-18
+              c_compiler: clang-18
+          # - host:
+          #   - cpp_compiler: g++-12
+          #     c_compiler: gcc-12
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           - { cpp_compiler: g++,        c_compiler: gcc,      image: macos-14,     generator: Unix Makefiles        }
         include:
           - build_type: Coverage
-            host: { cpp_compiler: clang++, c_compiler: clang, image: ubuntu-24.04, generator: Unix Makefiles        }
+            host: { cpp_compiler: clang++-18, c_compiler: clang-18, image: ubuntu-24.04, generator: Unix Makefiles }
 
     steps:
       - name: checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,21 @@ jobs:
       matrix:
         build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]
         host:
-          - os: macos-14
-            cpp_compiler: g++
-            c_compiler: gcc
+          # ubuntu-24.04 hosts
+          - os: ubuntu-24.04
+            cpp_compiler: clang++-16
+            c_compiler: clang-16
             generator: Unix Makefiles
+          - os: ubuntu-24.04
+            cpp_compiler: clang++-17
+            c_compiler: clang-17
+            generator: Unix Makefiles
+          - os: ubuntu-24.04
+            cpp_compiler: clang++-18
+            c_compiler: clang-18
+            generator: Unix Makefiles
+          # windows-2022 hosts
+          # macos-14 hosts
       # Set up a matrix to run the different configurations:
       # matrix:
       #   build_type: [Debug, RelWithDebInfo, Release, MinSizeRel]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         host:
           - os: ubuntu-24.04
             cpp_compiler: g++
-            c_compiler: g
+            c_compiler: gcc
             generator: Unix Makefiles
       # Set up a matrix to run the different configurations:
       # matrix:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,8 +11,8 @@
 `stf` is a header-only template math library built primarily for graphics.
 The library is split into a couple namespaces.
 
-| | |
-|-|-|
+| namespace | description |
+|-----------|-------------|
 | `math` | contains basic math structures and operations (eg `vector`, `matrix`, spherical coordinates) |
 | `geom` | contains geometric primitives (eg `segment`, `polyline`, and `polygon`) |
 | `gfx` | contains graphics-related structures (eg `rgba`) |
@@ -34,7 +34,7 @@ stfu::vec2 point(0, 0);     // unsigned integers
 ## building
 
 `stf` uses [cmake](https://cmake.org/) to generate a build system of your choice.
-CI builds `stf` with msvc/gcc/clang.
+GHA builds `stf` with a number of compilers on various operating systems.
 
 ## tests
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,20 @@
+# support
+
+`stf` officially supports the following combinations of operating systems and compilers.
+Other combinations may work but are not actively tested in our automated build.
+
+## windows
+
+* Visual Studio 16
+* Visual Studio 17
+* g++ 12
+
+## ubuntu
+
+* clang++ (versions 16, 17, 18)
+* g++ (versions 12, 13, 14)
+
+## macos
+
+* clang++ 15
+* g++ (versions 12, 13, 14)

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,13 @@
 2. maintainability
 3. performance
 
+## Documentation
+
+* [architecture](./docs/architecture.md)
+* [contributing](./docs/contributing.md)
+* [support](.docs/support.md)
+* [todo](./docs/todo.md)
+
 ## Note
 
 Unfortunately, the code coverage is a lie because the entire library is templated and an uninstantiated template (class or function) is not incoporated into coverage computations.

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,6 @@
 2. maintainability
 3. performance
 
-## Documentation
-
-* [architecture](./docs/architecture.md)
-* [contributing](./docs/contributing.md)
-* [support](.docs/support.md)
-* [todo](./docs/todo.md)
-
 ## Note
 
 Unfortunately, the code coverage is a lie because the entire library is templated and an uninstantiated template (class or function) is not incoporated into coverage computations.


### PR DESCRIPTION
## Summary

This PR sets up the automated build with specific OS versions so that changes don't occur under our feet. I also added a bunch of compiler versions to the automated build for more breadth.

As part of this, I have simplified our matrix configuration at the cost of verbosity. Each entry must specify the image/compiler/generator. We could do this with the matrix but then our include/exclude blocks would be unwieldly. I chose simplicity -- especially because the yml syntax allows for objects to be defined on the same line