### PR TITLE
Rename near and far

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,6 @@ coverage:
       default:
         informational: true
         target: 50% # the diff coverage must be 50%
-        
 
 # Pull request comments:
 # ----------------------

--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -319,12 +319,12 @@ namespace stf::cam
         // unscoped enum so we can use it as an array index
         enum side : size_t
         {
-            NEAR   = 0,
-            FAR    = 1,
-            LEFT   = 2,
-            RIGHT  = 3,
-            TOP    = 4,
-            BOTTOM = 5
+            nearp  = 0,
+            farp   = 1,
+            left   = 2,
+            right  = 3,
+            top    = 4,
+            bottom = 5
         };
 
     private:
@@ -355,11 +355,11 @@ namespace stf::cam
                 basis[1],
                 basis[2],
                 // frustum normals
-                planes[side::FAR].normal(),
-                planes[side::LEFT].normal(),
-                planes[side::RIGHT].normal(),
-                planes[side::TOP].normal(),
-                planes[side::BOTTOM].normal(),
+                planes[side::farp].normal(),
+                planes[side::left].normal(),
+                planes[side::right].normal(),
+                planes[side::top].normal(),
+                planes[side::bottom].normal(),
             };
             size_t i = 8;
             for (vec_t const& axis : frustum::edge_axes(basis, verts))
@@ -373,12 +373,12 @@ namespace stf::cam
 
         explicit frustum(vertices const& verts) : m_vertices(verts)
         {
-            m_planes[FAR]    = geom::fit_plane(verts.ftl, verts.fbl, verts.ftr);
-            m_planes[NEAR]   = geom::plane<T>(verts.ntl, -m_planes[FAR].normal());     // define near plane as a function of the far plane to avoid precision issues
-            m_planes[LEFT]   = geom::fit_plane(verts.ftl, verts.ntl, verts.fbl);
-            m_planes[RIGHT]  = geom::fit_plane(verts.ftr, verts.fbr, verts.ntr);
-            m_planes[TOP]    = geom::fit_plane(verts.ftl, verts.ftr, verts.ntl);
-            m_planes[BOTTOM] = geom::fit_plane(verts.fbr, verts.fbl, verts.nbr);
+            m_planes[farp]   = geom::fit_plane(verts.ftl, verts.fbl, verts.ftr);
+            m_planes[nearp]  = geom::plane<T>(verts.ntl, -m_planes[farp].normal());     // define near plane as a function of the far plane to avoid precision issues
+            m_planes[left]   = geom::fit_plane(verts.ftl, verts.ntl, verts.fbl);
+            m_planes[right]  = geom::fit_plane(verts.ftr, verts.fbr, verts.ntr);
+            m_planes[top]    = geom::fit_plane(verts.ftl, verts.ftr, verts.ntl);
+            m_planes[bottom] = geom::fit_plane(verts.fbr, verts.fbl, verts.nbr);
 
             std::vector<vec_t> points =
             {

--- a/code/src/stf/include/interface/stf/cam/frustum.hpp
+++ b/code/src/stf/include/interface/stf/cam/frustum.hpp
@@ -289,10 +289,10 @@ namespace stf::cam
 
                 // compute points on the near plane
                 {
-                    T half_height = camera.near * std::tan(math::constants<T>::half * camera.fov);
+                    T half_height = camera.nearp * std::tan(math::constants<T>::half * camera.fov);
                     T half_width = half_height * camera.aspect;
 
-                    vec_t center = camera.eye + look * camera.near;
+                    vec_t center = camera.eye + look * camera.nearp;
                     vec_t delta_up = up * half_height;
                     vec_t delta_right = right * half_width;
 
@@ -302,10 +302,10 @@ namespace stf::cam
 
                 // compute points on the far plane
                 {
-                    T half_height = camera.far * std::tan(math::constants<T>::half * camera.fov);
+                    T half_height = camera.farp * std::tan(math::constants<T>::half * camera.fov);
                     T half_width = half_height * camera.aspect;
 
-                    vec_t center = camera.eye + look * camera.far;
+                    vec_t center = camera.eye + look * camera.farp;
                     vec_t delta_up = up * half_height;
                     vec_t delta_right = right * half_width;
 

--- a/code/src/stf/include/interface/stf/cam/scamera.hpp
+++ b/code/src/stf/include/interface/stf/cam/scamera.hpp
@@ -44,8 +44,8 @@ namespace stf::cam
         static vec_t constexpr c_default_eye = vec_t(0);
         static T constexpr c_default_theta = math::constants<T>::half_pi;
         static T constexpr c_default_phi = math::constants<T>::pi;
-        static T constexpr c_default_near = T(0.1);
-        static T constexpr c_default_far = T(1000);
+        static T constexpr c_default_nearp = T(0.1);
+        static T constexpr c_default_farp = T(1000);
         static T constexpr c_default_fov = T(45) * math::constants<T>::pi / T(180);
         static T constexpr c_default_aspect = T(16) / T(9);
         /// @endcond
@@ -70,12 +70,12 @@ namespace stf::cam
         /**
          * @brief The near plane
          */
-        T near;
+        T nearp;
 
         /**
          * @brief The far plane
          */
-        T far;
+        T farp;
 
         /**
          * @brief The aspect ratio (w / h)
@@ -90,8 +90,8 @@ namespace stf::cam
         /**
          * @brief Fully qualified scamera constructor
          */
-        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _near, T const _far, T const _aspect, T const _fov) :
-            eye(_eye), theta(_theta), phi(_phi), near(_near), far(_far), aspect(_aspect), fov(_fov) {}
+        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _nearp, T const _farp, T const _aspect, T const _fov) :
+            eye(_eye), theta(_theta), phi(_phi), nearp(_nearp), farp(_farp), aspect(_aspect), fov(_fov) {}
 
         /**
          * @brief Default constructor
@@ -117,28 +117,28 @@ namespace stf::cam
          * @param [in] _theta 
          * @param [in] _phi 
          */
-        scamera(vec_t const& _eye, T const _theta, T const _phi) : scamera(_eye, _theta, _phi, c_default_near, c_default_far) {}
+        scamera(vec_t const& _eye, T const _theta, T const _phi) : scamera(_eye, _theta, _phi, c_default_nearp, c_default_farp) {}
 
         /**
          * @brief Construct from a position, orientation, and near/far plane
          * @param [in] _eye 
          * @param [in] _theta 
          * @param [in] _phi 
-         * @param [in] _near 
-         * @param [in] _far 
+         * @param [in] _nearp
+         * @param [in] _farp
          */
-        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _near, T const _far) : scamera(_eye, _theta, _phi, _near, _far, c_default_aspect) {}
+        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _nearp, T const _farp) : scamera(_eye, _theta, _phi, _nearp, _farp, c_default_aspect) {}
 
         /**
          * @brief Construct from a position, orientation, near/far plane, and aspect ratio
          * @param [in] _eye 
          * @param [in] _theta 
          * @param [in] _phi 
-         * @param [in] _near 
-         * @param [in] _far 
+         * @param [in] _nearp 
+         * @param [in] _farp 
          * @param [in] _aspect 
          */
-        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _near, T const _far, T const _aspect) : scamera(_eye, _theta, _phi, _near, _far, _aspect, c_default_fov) {}
+        scamera(vec_t const& _eye, T const _theta, T const _phi, T const _nearp, T const _farp, T const _aspect) : scamera(_eye, _theta, _phi, _nearp, _farp, _aspect, c_default_fov) {}
         
         /**
          * @brief Construct from a theta
@@ -203,7 +203,7 @@ namespace stf::cam
          * @brief Compute the perspective projection matrix for the scamera
          * @return The perspective projection matrix for @p this
          */
-        mtx_t perspective() const { return math::perspective<T>(fov, aspect, near, far); }
+        mtx_t perspective() const { return math::perspective<T>(fov, aspect, nearp, farp); }
 
         /**
          * @brief Compute the inverse of the view matrix for the scamera
@@ -234,8 +234,8 @@ namespace stf::cam
         return equ(lhs.eye, rhs.eye, eps)
                 && math::equ(lhs.theta, rhs.theta, eps)
                 && math::equ(lhs.phi, rhs.phi, eps)
-                && math::equ(lhs.near, rhs.near, eps)
-                && math::equ(lhs.far, rhs.far, eps)
+                && math::equ(lhs.nearp, rhs.nearp, eps)
+                && math::equ(lhs.farp, rhs.farp, eps)
                 && math::equ(lhs.aspect, rhs.aspect, eps)
                 && math::equ(lhs.fov, rhs.fov, eps);
     }
@@ -299,8 +299,8 @@ namespace stf::cam
         result.eye    = math::lerp(lhs.eye, rhs.eye, t);
         result.theta  = math::lerp(lhs.theta, math::closest_equiv_angle(rhs.theta, lhs.theta), t);
         result.phi    = math::lerp(lhs.phi, math::closest_equiv_angle(rhs.phi, lhs.phi), t);
-        result.near   = math::lerp(lhs.near, rhs.near, t);
-        result.far    = math::lerp(lhs.far, rhs.far, t);
+        result.nearp  = math::lerp(lhs.nearp, rhs.nearp, t);
+        result.farp   = math::lerp(lhs.farp, rhs.farp, t);
         result.aspect = math::lerp(lhs.aspect, rhs.aspect, t);
         result.fov    = math::lerp(lhs.fov, rhs.fov, t);
         return result;
@@ -373,8 +373,8 @@ namespace stf::cam
         s << " eye: " << rhs.eye;
         s << " theta: " << rhs.theta;
         s << " phi: " << rhs.phi;
-        s << " near: " << rhs.near;
-        s << " far: " << rhs.far;
+        s << " nearp: " << rhs.nearp;
+        s << " farp: " << rhs.farp;
         s << " aspect: " << rhs.aspect;
         s << " fov: " << rhs.fov;
         s << " ]";


### PR DESCRIPTION
## Summary

I am encountering too many issues with windows and the `near`/`far` macros. I am renaming those attributes to `nearp`/`farp`